### PR TITLE
Fix `Too many open files` error

### DIFF
--- a/src/energomera_hass_mqtt/__init__.py
+++ b/src/energomera_hass_mqtt/__init__.py
@@ -235,6 +235,7 @@ class IecToHassSensor:  # pylint: disable=too-many-instance-attributes
                               self._config_param, str(exc))
                 continue
 
+
 # pylint: disable=too-many-instance-attributes
 class EnergomeraHassMqtt:
     """


### PR DESCRIPTION
* Fixed issue when the program starts to report ` Got exception  while processing, skipping to next cycle. Details: OSError(24, 'Too  many open files')` upon running for some time - MQTT client has been  create in `IecToHassSensor` class that is instantiated for every  meter's parameter on every run, which is too much. Moved creating MQTT  client to constructor of `EnergomeraHassMqtt` class instead