### PR TITLE
Fixed interpolated expressions in the configuration across day/month changes

### DIFF
--- a/tests/test_energomera.py
+++ b/tests/test_energomera.py
@@ -25,6 +25,7 @@ Tests for 'energomera_hass_mqtt' package
 import sys
 import json
 from unittest.mock import call, MagicMock, patch, mock_open
+from freezegun import freeze_time
 try:
     from unittest.mock import AsyncMock
 except ImportError:
@@ -813,6 +814,7 @@ mqtt_publish_calls = [
 ]
 
 
+@freeze_time("2022-05-01")
 def run_main():
     '''
     Execute the main flow interacting with the device and MQTT.

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ deps =
 	pytest
 	pytest-cov
 	mock;python_version<"3.8"
+	freezegun
 setenv =
 	# Ensure the module under test will be found under `src/` directory, in
 	# case of any test command below will attempt importing it. In particular,


### PR DESCRIPTION
 + `EnergomeraConfig` class has been fixed to properly support expressions interpolated across multiple calls to `interpolate()` over same configuration instance - it is done by holding an internal copy of whole original configuration object, and `interpolate()` method now uses it as the source for the values to interpolate, since the original copy holds unmodified expressions. Previsouly, interpolation
  has been done in place losing the exrpessions upon first run, and that  caused problems when day/month changes - the values expected to be  interpolated for the new date have been holding the outdated values.