### PR TITLE
Online sensor support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,6 +76,8 @@ Configuration file is in YAML format and supports following elements:
             # (string) Password to meter for administrative session, manufacturer's
             #  default is '777777'
             password:
+            # (number) default ``30``: Timeout for meter communications
+            timeout:
         # MQTT parameters
         mqtt:
             # (string) Hostname or IP address of MQTT broker

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,10 @@ pythonpath = [
 ]
 log_cli = 1
 log_cli_level = "error"
+
+[tool.pylint.typecheck]
+signature-mutators = [
+	# Ignore mutations (number of function arguments) introduced by
+	# `patch.object` decorator of `unittest.mock`
+	"unittest.mock._patch_object"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ pythonpath = [
 log_cli = 1
 log_cli_level = "error"
 
+[tool.pylint.main]
+load-plugins = "pylint.extensions.no_self_use"
+
 [tool.pylint.typecheck]
 signature-mutators = [
 	# Ignore mutations (number of function arguments) introduced by

--- a/src/energomera_hass_mqtt/__init__.py
+++ b/src/energomera_hass_mqtt/__init__.py
@@ -349,7 +349,7 @@ class IecToHassBinarySensor(IecToHassSensor):
             )
 
         return dict(
-            value='on' if b_value else 'off'
+            value='ON' if b_value else 'OFF'
         )
 
 
@@ -532,7 +532,7 @@ class EnergomeraHassMqtt:
         param = Dict(
             address='IS_ONLINE',
             name='Meter online status',
-            device_class='power',
+            device_class='connectivity',
             additional_data=None,
             response_idx=None,
             entity_name=None,

--- a/src/energomera_hass_mqtt/__init__.py
+++ b/src/energomera_hass_mqtt/__init__.py
@@ -384,8 +384,6 @@ class EnergomeraHassMqtt:
     MQTT.
 
     :param EnergomeraConfig config: Configuration state
-    :param ssl.SSLContext mqtt_tls_context: SSL/TLS context to use while
-      connecting to MQTT broker, necessary if it uses SSL/TLS
     """
 
     @staticmethod
@@ -410,8 +408,6 @@ class EnergomeraHassMqtt:
 
     def __init__(
         self, config,
-        # Required for TLS-enabled MQTT broker
-        mqtt_tls_context=ssl.SSLContext(),
     ):
         self._config = config
         # Override the method in the `iec62056_21` library with the specific
@@ -430,6 +426,12 @@ class EnergomeraHassMqtt:
             )
         )
 
+        mqtt_tls_context = None
+        if config.of.mqtt.tls:
+            _LOGGER.debug('Enabling TLS for MQTT connection')
+            # Required for TLS-enabled MQTT broker
+            mqtt_tls_context=ssl.SSLContext()
+
         self._mqtt_client = MqttClient(
             hostname=config.of.mqtt.host, username=config.of.mqtt.user,
             password=config.of.mqtt.password, tls_context=mqtt_tls_context
@@ -438,7 +440,6 @@ class EnergomeraHassMqtt:
         self._model = None
         self._serial_number = None
         self._sw_version = None
-        self._mqtt_tls_context = mqtt_tls_context
 
     def iec_read_values(self, address, additional_data=None):
         """

--- a/src/energomera_hass_mqtt/__init__.py
+++ b/src/energomera_hass_mqtt/__init__.py
@@ -200,7 +200,7 @@ class IecToHassSensor:  # pylint: disable=too-many-instance-attributes
             value_template='{{ value_json.value }}',
         )
 
-    def hass_state_payload(self, value):
+    def hass_state_payload(self, value):  # pylint: disable=no-self-use
         """
         Returns HASS state payload for the item.
 
@@ -332,7 +332,7 @@ class IecToHassBinarySensor(IecToHassSensor):
             value_template='{{ value_json.value }}',
         )
 
-    def hass_state_payload(self, value):
+    def hass_state_payload(self, value):  # pylint: disable=no-self-use
         """
         Transforms the binary sensor payload to the format understood by HASS
         MQTT discovery for the sensor type.

--- a/src/energomera_hass_mqtt/config.py
+++ b/src/energomera_hass_mqtt/config.py
@@ -107,11 +107,12 @@ class EnergomeraConfig:
             'meter': {
                 'port': str,
                 'password': str,
+                Optional('timeout', default=DEFAULT_CONFIG.meter.timeout): int,
             },
             'mqtt': {
                 'host': str,
-                Optional('user'): str,
-                Optional('password'): str,
+                Optional('user', default=None): str,
+                Optional('password', default=None): str,
                 Optional('hass_discovery_prefix',
                          default='homeassistant'): str,
             },

--- a/src/energomera_hass_mqtt/config.py
+++ b/src/energomera_hass_mqtt/config.py
@@ -115,6 +115,7 @@ class EnergomeraConfig:
                 Optional('password', default=None): str,
                 Optional('hass_discovery_prefix',
                          default='homeassistant'): str,
+                Optional('tls', default=True): bool,
             },
             Optional('parameters', default=DEFAULT_CONFIG.parameters): [
                 Schema({

--- a/src/energomera_hass_mqtt/const.py
+++ b/src/energomera_hass_mqtt/const.py
@@ -35,6 +35,9 @@ DEFAULT_CONFIG = Dict(
     meter=dict(
         timeout=30,
     ),
+    mqtt=dict(
+        tls=True,
+    ),
     parameters=[
         dict(address='ET0PE',
              name='Cumulative energy',

--- a/src/energomera_hass_mqtt/const.py
+++ b/src/energomera_hass_mqtt/const.py
@@ -32,6 +32,9 @@ DEFAULT_CONFIG = Dict(
         intercycle_delay=30,
         logging_level='error',
     ),
+    meter=dict(
+        timeout=30,
+    ),
     parameters=[
         dict(address='ET0PE',
              name='Cumulative energy',

--- a/src/energomera_hass_mqtt/main.py
+++ b/src/energomera_hass_mqtt/main.py
@@ -59,8 +59,8 @@ async def async_main():
         try:
             await client.iec_read_admin()
         except Exception as exc:  # pylint: disable=broad-except
-            print('Got exception while processing, skipping to next cycle.'
-                  f' Details: {repr(exc)}')
+            logging.error('Got exception while processing,'
+                          ' skipping to next cycle: %s', exc, exc_info=True)
         if config.of.general.oneshot:
             break
         await asyncio.sleep(config.of.general.intercycle_delay)

--- a/src/energomera_hass_mqtt/mqtt_client.py
+++ b/src/energomera_hass_mqtt/mqtt_client.py
@@ -29,6 +29,12 @@ _LOGGER = logging.getLogger(__name__)
 
 class MqttClient(asyncio_mqtt.Client):
     """
+    Class attribute allowing to provide MQTT keepalive down to MQTT client.
+    Used only by tests at the moment, thus no interface controlling the
+    attribute is provided.
+    """
+    _keepalive = None
+    """
     The class extends the `asyncio_mqtt.Client` to provide better convenience
     working with last wills. Namely, the original class only allows setting the
     last will thru its constructor, while the `EnergomeraHassMqtt` consuming it
@@ -39,6 +45,9 @@ class MqttClient(asyncio_mqtt.Client):
     """
     def __init__(self, *args, **kwargs):
         self._will_set = 'will' in kwargs
+        # Pass keepalive option down to parent class if set
+        if self._keepalive:
+            kwargs['keepalive'] = self._keepalive
         super().__init__(logger=_LOGGER, *args, **kwargs)
 
     def will_set(self, *args, **kwargs):

--- a/src/energomera_hass_mqtt/mqtt_client.py
+++ b/src/energomera_hass_mqtt/mqtt_client.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2022 Ilia Sotnikov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""
+The package provides additional functionality over `asyncio_mqtt`.
+"""
+import logging
+import asyncio_mqtt
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class MqttClient(asyncio_mqtt.Client):
+    """
+    The class extends the `asyncio_mqtt.Client` to provide better convenience
+    working with last wills. Namely, the original class only allows setting the
+    last will thru its constructor, while the `EnergomeraHassMqtt` consuming it
+    only has required property for that around actual publish calls.
+
+    :param args: Pass-through positional arguments for parent class
+    :param kwargs: Pass-through keyword arguments for parent class
+    """
+    def __init__(self, *args, **kwargs):
+        self._will_set = 'will' in kwargs
+        super().__init__(*args, **kwargs)
+
+    def will_set(self, *args, **kwargs):
+        """
+        Allows setting last will to the underlying MQTT client.
+
+        Logs error and skips updating the last will if one has already been set
+        (either via the method or through the constructor)
+
+        :param args: Pass-through positional arguments for parent method
+        :param kwargs: Pass-through keyword arguments for parent method
+        """
+        if self._will_set:
+            _LOGGER.error('Refusing to overwrite last will')
+            return
+        self._client.will_set(*args, **kwargs)
+        self._will_set = True
+
+    def will_clear(self):
+        """
+        Clears the last will might have been set previously.
+        """
+        self._client.will_clear()
+        self._will_set = False

--- a/src/energomera_hass_mqtt/mqtt_client.py
+++ b/src/energomera_hass_mqtt/mqtt_client.py
@@ -39,20 +39,19 @@ class MqttClient(asyncio_mqtt.Client):
     """
     def __init__(self, *args, **kwargs):
         self._will_set = 'will' in kwargs
-        super().__init__(*args, **kwargs)
+        super().__init__(logger=_LOGGER, *args, **kwargs)
 
     def will_set(self, *args, **kwargs):
         """
         Allows setting last will to the underlying MQTT client.
 
-        Logs error and skips updating the last will if one has already been set
-        (either via the method or through the constructor)
+        Skips updating the last will if one has already been set (either via
+        the method or through the constructor).
 
         :param args: Pass-through positional arguments for parent method
         :param kwargs: Pass-through keyword arguments for parent method
         """
         if self._will_set:
-            _LOGGER.error('Refusing to overwrite last will')
             return
         self._client.will_set(*args, **kwargs)
         self._will_set = True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -57,6 +57,7 @@ def test_valid_config_file():
         'meter': {
             'port': 'dummy_serial',
             'password': 'dummy_password',
+            'timeout': 30,
         },
         'mqtt': {
             'host': 'a_mqtt_host',

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -64,6 +64,7 @@ def test_valid_config_file():
             'user': 'a_mqtt_user',
             'password': 'mqtt_dummy_password',
             'hass_discovery_prefix': 'homeassistant',
+            'tls': True,
         },
         'parameters': [
             {

--- a/tests/test_energomera.py
+++ b/tests/test_energomera.py
@@ -981,7 +981,7 @@ def run_main():
 
 @freeze_time("2022-05-01")
 # Mock the calls we interested in
-@patch.object(asyncio_mqtt.client.Client, 'publish')
+@patch.object(asyncio_mqtt.client.Client, 'publish', new_callable=AsyncMock)
 @patch.object(iec62056_21.transports.SerialTransport, '_send')
 @patch.object(iec62056_21.transports.SerialTransport, '_recv')
 # Mock certain methods of 'iec62056_21' package (serial communications) and
@@ -1080,7 +1080,7 @@ def test_mqtt_publish(mqtt_call, mqtt_expected):
     assert mqtt_call == mqtt_expected
 
 
-@patch.object(asyncio_mqtt.client.Client, 'publish')
+@patch.object(asyncio_mqtt.client.Client, 'publish', new_callable=AsyncMock)
 @patch.object(asyncio_mqtt.client.Client, 'connect', new_callable=AsyncMock)
 @patch.object(iec62056_21.transports.SerialTransport, '_recv')
 @patch.object(iec62056_21.transports.SerialTransport, '_send')

--- a/tests/test_energomera.py
+++ b/tests/test_energomera.py
@@ -839,7 +839,7 @@ mqtt_publish_calls = [
                     'model': 'CE301',
                     'sw_version': '12',
                 },
-                'device_class': 'power',
+                'device_class': 'connectivity',
                 'unique_id': 'CE301_00123456_IS_ONLINE',
                 'state_topic': 'homeassistant/binary_sensor/CE301_00123456'
                                '/CE301_00123456_IS_ONLINE'
@@ -852,11 +852,11 @@ mqtt_publish_calls = [
     call(
         topic='homeassistant/binary_sensor/CE301_00123456'
         '/CE301_00123456_IS_ONLINE/state',
-        payload=json.dumps({'value': 'on'}),
+        payload=json.dumps({'value': 'ON'}),
         will=dict(
             topic='homeassistant/binary_sensor/CE301_00123456'
             '/CE301_00123456_IS_ONLINE/state',
-            payload=json.dumps({'value': 'off'}),
+            payload=json.dumps({'value': 'OFF'}),
         ),
     ),
 ]
@@ -1105,10 +1105,10 @@ def test_online_sensor():
     assert call(
         topic='homeassistant/binary_sensor/CE301_00123456'
         '/CE301_00123456_IS_ONLINE/state',
-        payload=json.dumps({'value': 'off'}),
+        payload=json.dumps({'value': 'OFF'}),
         will=dict(
             topic='homeassistant/binary_sensor/CE301_00123456'
             '/CE301_00123456_IS_ONLINE/state',
-            payload=json.dumps({'value': 'off'}),
+            payload=json.dumps({'value': 'OFF'}),
         ),
     ) in mqtt_publish_call_args_for_timeout

--- a/tests/test_energomera.py
+++ b/tests/test_energomera.py
@@ -24,6 +24,12 @@ Tests for 'energomera_hass_mqtt' package
 '''
 import sys
 import json
+try:
+    from unittest.mock import AsyncMock
+except ImportError:
+    # AsyncMock introduced in Python 3.8, import from alternative package if
+    # older
+    from mock import AsyncMock
 from unittest.mock import call, patch, mock_open
 from functools import reduce
 from freezegun import freeze_time
@@ -983,7 +989,7 @@ def run_main():
 @patch.object(iec62056_21.transports.SerialTransport, 'switch_baudrate')
 @patch.object(iec62056_21.transports.SerialTransport, 'disconnect')
 @patch.object(iec62056_21.transports.SerialTransport, 'connect')
-@patch.object(asyncio_mqtt.client.Client, 'connect')
+@patch.object(asyncio_mqtt.client.Client, 'connect', new_callable=AsyncMock)
 def run_main_with_mocks(
     _mqtt_connect_mock, _serial_connect_mock, _serial_disconnect_mock,
     _serial_switch_baudrate_mock,
@@ -1075,7 +1081,7 @@ def test_mqtt_publish(mqtt_call, mqtt_expected):
 
 
 @patch.object(asyncio_mqtt.client.Client, 'publish')
-@patch.object(asyncio_mqtt.client.Client, 'connect')
+@patch.object(asyncio_mqtt.client.Client, 'connect', new_callable=AsyncMock)
 @patch.object(iec62056_21.transports.SerialTransport, '_recv')
 @patch.object(iec62056_21.transports.SerialTransport, '_send')
 @patch.object(iec62056_21.transports.SerialTransport, 'connect')

--- a/tests/test_energomera.py
+++ b/tests/test_energomera.py
@@ -1039,7 +1039,7 @@ def generate_mqtt_tests(call_args):
     ids = []
     for (exp, arg) in zip(mqtt_publish_calls, call_args):
         values.append((arg, exp))
-        ids.append(exp.kwargs.get('topic', str(exp)))
+        ids.append(str(exp.kwargs.get('topic', exp)))
 
     return {'argvalues': values, 'ids': ids}
 

--- a/tests/test_energomera.py
+++ b/tests/test_energomera.py
@@ -24,15 +24,9 @@ Tests for 'energomera_hass_mqtt' package
 '''
 import sys
 import json
-from unittest.mock import call, MagicMock, patch, mock_open
-from freezegun import freeze_time
-try:
-    from unittest.mock import AsyncMock
-except ImportError:
-    # AsyncMock introduced in Python 3.8, import from alternative package if
-    # older
-    from mock import AsyncMock
+from unittest.mock import call, patch, mock_open
 from functools import reduce
+from freezegun import freeze_time
 import pytest
 import asyncio_mqtt.client
 import iec62056_21.transports
@@ -184,7 +178,8 @@ serial_exchange = [
 # serial exchange above
 mqtt_publish_calls = [
     call(
-        'homeassistant/sensor/CE301_00123456/CE301_00123456_ET0PE/config',
+        topic='homeassistant/sensor/CE301_00123456'
+        '/CE301_00123456_ET0PE/config',
         payload=json.dumps(
             {
                 'name': 'Cumulative energy',
@@ -206,11 +201,12 @@ mqtt_publish_calls = [
         retain=True,
     ),
     call(
-        'homeassistant/sensor/CE301_00123456/CE301_00123456_ET0PE/state',
+        topic='homeassistant/sensor/CE301_00123456/CE301_00123456_ET0PE/state',
         payload=json.dumps({'value': '16907.9477764'}),
     ),
     call(
-        'homeassistant/sensor/CE301_00123456/CE301_00123456_ECMPE/config',
+        topic='homeassistant/sensor/CE301_00123456'
+        '/CE301_00123456_ECMPE/config',
         payload=json.dumps(
             {
                 'name': 'Monthly energy',
@@ -232,11 +228,11 @@ mqtt_publish_calls = [
         retain=True,
     ),
     call(
-        'homeassistant/sensor/CE301_00123456/CE301_00123456_ECMPE/state',
+        topic='homeassistant/sensor/CE301_00123456/CE301_00123456_ECMPE/state',
         payload=json.dumps({'value': '357.8505119'}),
     ),
     call(
-        'homeassistant/sensor/CE301_00123456'
+        topic='homeassistant/sensor/CE301_00123456'
         '/CE301_00123456_ENMPE_PREV_MONTH/config',
         payload=json.dumps(
             {
@@ -259,12 +255,12 @@ mqtt_publish_calls = [
         retain=True,
     ),
     call(
-        'homeassistant/sensor/CE301_00123456'
+        topic='homeassistant/sensor/CE301_00123456'
         '/CE301_00123456_ENMPE_PREV_MONTH/state',
         payload=json.dumps({'value': '16550.0972645'}),
     ),
     call(
-        'homeassistant/sensor/CE301_00123456'
+        topic='homeassistant/sensor/CE301_00123456'
         '/CE301_00123456_ECMPE_PREV_MONTH/config',
         payload=json.dumps(
             {
@@ -287,12 +283,13 @@ mqtt_publish_calls = [
         retain=True,
     ),
     call(
-        'homeassistant/sensor/CE301_00123456'
+        topic='homeassistant/sensor/CE301_00123456'
         '/CE301_00123456_ECMPE_PREV_MONTH/state',
         payload=json.dumps({'value': '477.8955487'}),
     ),
     call(
-        'homeassistant/sensor/CE301_00123456/CE301_00123456_ECDPE/config',
+        topic='homeassistant/sensor/CE301_00123456'
+        '/CE301_00123456_ECDPE/config',
         payload=json.dumps(
             {
                 'name': 'Daily energy',
@@ -314,11 +311,11 @@ mqtt_publish_calls = [
         retain=True,
     ),
     call(
-        'homeassistant/sensor/CE301_00123456/CE301_00123456_ECDPE/state',
+        topic='homeassistant/sensor/CE301_00123456/CE301_00123456_ECDPE/state',
         payload=json.dumps({'value': '13.7433546'}),
     ),
     call(
-        'homeassistant/sensor/CE301_00123456'
+        topic='homeassistant/sensor/CE301_00123456'
         '/CE301_00123456_POWPP_0/config',
         payload=json.dumps(
             {
@@ -341,11 +338,12 @@ mqtt_publish_calls = [
         retain=True,
     ),
     call(
-        'homeassistant/sensor/CE301_00123456/CE301_00123456_POWPP_0/state',
+        topic='homeassistant/sensor/CE301_00123456'
+        '/CE301_00123456_POWPP_0/state',
         payload=json.dumps({'value': '0.0592'}),
     ),
     call(
-        'homeassistant/sensor/CE301_00123456'
+        topic='homeassistant/sensor/CE301_00123456'
         '/CE301_00123456_POWPP_1/config',
         payload=json.dumps(
             {
@@ -368,11 +366,12 @@ mqtt_publish_calls = [
         retain=True,
     ),
     call(
-        'homeassistant/sensor/CE301_00123456/CE301_00123456_POWPP_1/state',
+        topic='homeassistant/sensor/CE301_00123456'
+        '/CE301_00123456_POWPP_1/state',
         payload=json.dumps({'value': '0.4402'}),
     ),
     call(
-        'homeassistant/sensor/CE301_00123456'
+        topic='homeassistant/sensor/CE301_00123456'
         '/CE301_00123456_POWPP_2/config',
         payload=json.dumps(
             {
@@ -395,11 +394,13 @@ mqtt_publish_calls = [
         retain=True,
     ),
     call(
-        'homeassistant/sensor/CE301_00123456/CE301_00123456_POWPP_2/state',
+        topic='homeassistant/sensor/CE301_00123456'
+        '/CE301_00123456_POWPP_2/state',
         payload=json.dumps({'value': '0.054'}),
     ),
     call(
-        'homeassistant/sensor/CE301_00123456/CE301_00123456_POWEP/config',
+        topic='homeassistant/sensor/CE301_00123456'
+        '/CE301_00123456_POWEP/config',
         payload=json.dumps(
             {
                 'name': 'Active energy',
@@ -421,11 +422,11 @@ mqtt_publish_calls = [
         retain=True,
     ),
     call(
-        'homeassistant/sensor/CE301_00123456/CE301_00123456_POWEP/state',
+        topic='homeassistant/sensor/CE301_00123456/CE301_00123456_POWEP/state',
         payload=json.dumps({'value': '0.5266'}),
     ),
     call(
-        'homeassistant/sensor/CE301_00123456'
+        topic='homeassistant/sensor/CE301_00123456'
         '/CE301_00123456_VOLTA_0/config',
         payload=json.dumps(
             {
@@ -448,11 +449,12 @@ mqtt_publish_calls = [
         retain=True,
     ),
     call(
-        'homeassistant/sensor/CE301_00123456/CE301_00123456_VOLTA_0/state',
+        topic='homeassistant/sensor/CE301_00123456'
+        '/CE301_00123456_VOLTA_0/state',
         payload=json.dumps({'value': '233.751'}),
     ),
     call(
-        'homeassistant/sensor/CE301_00123456'
+        topic='homeassistant/sensor/CE301_00123456'
         '/CE301_00123456_VOLTA_1/config',
         payload=json.dumps(
             {
@@ -475,11 +477,12 @@ mqtt_publish_calls = [
         retain=True,
     ),
     call(
-        'homeassistant/sensor/CE301_00123456/CE301_00123456_VOLTA_1/state',
+        topic='homeassistant/sensor/CE301_00123456'
+        '/CE301_00123456_VOLTA_1/state',
         payload=json.dumps({'value': '235.418'}),
     ),
     call(
-        'homeassistant/sensor/CE301_00123456'
+        topic='homeassistant/sensor/CE301_00123456'
         '/CE301_00123456_VOLTA_2/config',
         payload=json.dumps(
             {
@@ -502,11 +505,13 @@ mqtt_publish_calls = [
         retain=True,
     ),
     call(
-        'homeassistant/sensor/CE301_00123456/CE301_00123456_VOLTA_2/state',
+        topic='homeassistant/sensor/CE301_00123456'
+        '/CE301_00123456_VOLTA_2/state',
         payload=json.dumps({'value': '234.796'}),
     ),
     call(
-        'homeassistant/sensor/CE301_00123456/CE301_00123456_VNULL/config',
+        topic='homeassistant/sensor/CE301_00123456'
+        '/CE301_00123456_VNULL/config',
         payload=json.dumps(
             {
                 'name': 'Neutral voltage',
@@ -528,11 +533,11 @@ mqtt_publish_calls = [
         retain=True,
     ),
     call(
-        'homeassistant/sensor/CE301_00123456/CE301_00123456_VNULL/state',
+        topic='homeassistant/sensor/CE301_00123456/CE301_00123456_VNULL/state',
         payload=json.dumps({'value': '0'}),
     ),
     call(
-        'homeassistant/sensor/CE301_00123456'
+        topic='homeassistant/sensor/CE301_00123456'
         '/CE301_00123456_CURRE_0/config',
         payload=json.dumps(
             {
@@ -555,11 +560,12 @@ mqtt_publish_calls = [
         retain=True,
     ),
     call(
-        'homeassistant/sensor/CE301_00123456/CE301_00123456_CURRE_0/state',
+        topic='homeassistant/sensor/CE301_00123456'
+        '/CE301_00123456_CURRE_0/state',
         payload=json.dumps({'value': '1.479'}),
     ),
     call(
-        'homeassistant/sensor/CE301_00123456'
+        topic='homeassistant/sensor/CE301_00123456'
         '/CE301_00123456_CURRE_1/config',
         payload=json.dumps(
             {
@@ -582,11 +588,12 @@ mqtt_publish_calls = [
         retain=True,
     ),
     call(
-        'homeassistant/sensor/CE301_00123456/CE301_00123456_CURRE_1/state',
+        topic='homeassistant/sensor/CE301_00123456'
+        '/CE301_00123456_CURRE_1/state',
         payload=json.dumps({'value': '2.8716'}),
     ),
     call(
-        'homeassistant/sensor/CE301_00123456'
+        topic='homeassistant/sensor/CE301_00123456'
         '/CE301_00123456_CURRE_2/config',
         payload=json.dumps(
             {
@@ -609,11 +616,13 @@ mqtt_publish_calls = [
         retain=True,
     ),
     call(
-        'homeassistant/sensor/CE301_00123456/CE301_00123456_CURRE_2/state',
+        topic='homeassistant/sensor/CE301_00123456'
+        '/CE301_00123456_CURRE_2/state',
         payload=json.dumps({'value': '0.782'}),
     ),
     call(
-        'homeassistant/sensor/CE301_00123456/CE301_00123456_FREQU/config',
+        topic='homeassistant/sensor/CE301_00123456'
+        '/CE301_00123456_FREQU/config',
         payload=json.dumps(
             {
                 'name': 'Frequency',
@@ -635,12 +644,13 @@ mqtt_publish_calls = [
         retain=True,
     ),
     call(
-        'homeassistant/sensor/CE301_00123456/CE301_00123456_FREQU/state',
+        topic='homeassistant/sensor/CE301_00123456'
+        '/CE301_00123456_FREQU/state',
         payload=json.dumps({'value': '49.96'}),
     ),
     # MQTT calls for HASS entry with auto-indexed name
     call(
-        'homeassistant/sensor/CE301_00123456'
+        topic='homeassistant/sensor/CE301_00123456'
         '/CE301_00123456_CURRE_INDEXED_0/config',
         payload=json.dumps(
             {
@@ -663,12 +673,12 @@ mqtt_publish_calls = [
         retain=True,
     ),
     call(
-        'homeassistant/sensor/CE301_00123456'
+        topic='homeassistant/sensor/CE301_00123456'
         '/CE301_00123456_CURRE_INDEXED_0/state',
         payload=json.dumps({'value': '1.479'}),
     ),
     call(
-        'homeassistant/sensor/CE301_00123456'
+        topic='homeassistant/sensor/CE301_00123456'
         '/CE301_00123456_CURRE_INDEXED_1/config',
         payload=json.dumps(
             {
@@ -691,12 +701,12 @@ mqtt_publish_calls = [
         retain=True,
     ),
     call(
-        'homeassistant/sensor/CE301_00123456'
+        topic='homeassistant/sensor/CE301_00123456'
         '/CE301_00123456_CURRE_INDEXED_1/state',
         payload=json.dumps({'value': '2.8716'}),
     ),
     call(
-        'homeassistant/sensor/CE301_00123456'
+        topic='homeassistant/sensor/CE301_00123456'
         '/CE301_00123456_CURRE_INDEXED_2/config',
         payload=json.dumps(
             {
@@ -719,13 +729,13 @@ mqtt_publish_calls = [
         retain=True,
     ),
     call(
-        'homeassistant/sensor/CE301_00123456'
+        topic='homeassistant/sensor/CE301_00123456'
         '/CE301_00123456_CURRE_INDEXED_2/state',
         payload=json.dumps({'value': '0.782'}),
     ),
     # MQTT calls for HASS entry with fallback names
     call(
-        'homeassistant/sensor/CE301_00123456'
+        topic='homeassistant/sensor/CE301_00123456'
         '/CE301_00123456_CURRE_INDEXED_FALLBACK_0/config',
         payload=json.dumps(
             {
@@ -749,12 +759,12 @@ mqtt_publish_calls = [
         retain=True,
     ),
     call(
-        'homeassistant/sensor/CE301_00123456'
+        topic='homeassistant/sensor/CE301_00123456'
         '/CE301_00123456_CURRE_INDEXED_FALLBACK_0/state',
         payload=json.dumps({'value': '1.479'}),
     ),
     call(
-        'homeassistant/sensor/CE301_00123456'
+        topic='homeassistant/sensor/CE301_00123456'
         '/CE301_00123456_CURRE_INDEXED_FALLBACK_1/config',
         payload=json.dumps(
             {
@@ -778,12 +788,12 @@ mqtt_publish_calls = [
         retain=True,
     ),
     call(
-        'homeassistant/sensor/CE301_00123456'
+        topic='homeassistant/sensor/CE301_00123456'
         '/CE301_00123456_CURRE_INDEXED_FALLBACK_1/state',
         payload=json.dumps({'value': '2.8716'}),
     ),
     call(
-        'homeassistant/sensor/CE301_00123456'
+        topic='homeassistant/sensor/CE301_00123456'
         '/CE301_00123456_CURRE_INDEXED_FALLBACK_2/config',
         payload=json.dumps(
             {
@@ -807,51 +817,57 @@ mqtt_publish_calls = [
         retain=True,
     ),
     call(
-        'homeassistant/sensor/CE301_00123456'
+        topic='homeassistant/sensor/CE301_00123456'
         '/CE301_00123456_CURRE_INDEXED_FALLBACK_2/state',
         payload=json.dumps({'value': '0.782'}),
+    ),
+    call(
+        topic='homeassistant/binary_sensor/CE301_00123456'
+        '/CE301_00123456_IS_ONLINE/config',
+        payload=json.dumps(
+            {
+                'name': 'Meter online status',
+                'device': {
+                    'name': '00123456',
+                    'ids': 'CE301_00123456',
+                    'model': 'CE301',
+                    'sw_version': '12',
+                },
+                'device_class': 'power',
+                'unique_id': 'CE301_00123456_IS_ONLINE',
+                'state_topic': 'homeassistant/binary_sensor/CE301_00123456'
+                               '/CE301_00123456_IS_ONLINE'
+                               '/state',
+                'value_template': '{{ value_json.value }}',
+            }
+        ),
+        retain=True,
+    ),
+    call(
+        topic='homeassistant/binary_sensor/CE301_00123456'
+        '/CE301_00123456_IS_ONLINE/state',
+        payload=json.dumps({'value': 'on'}),
+        will=dict(
+            topic='homeassistant/binary_sensor/CE301_00123456'
+            '/CE301_00123456_IS_ONLINE/state',
+            payload=json.dumps({'value': 'off'}),
+        ),
     ),
 ]
 
 
-@freeze_time("2022-05-01")
 def run_main():
     '''
-    Execute the main flow interacting with the device and MQTT.
+    Executes the meter client with given configuration.
     '''
 
-    # Mock certain methods of 'iec62056_21' package (serial communications) and
-    # 'asyncio_mqtt' (MQTT) to prevent serial/networking calls
-    asyncio_mqtt.client.Client.connect = AsyncMock()
-    iec62056_21.transports.SerialTransport.switch_baudrate = MagicMock()
-    iec62056_21.transports.SerialTransport.connect = MagicMock()
-    iec62056_21.transports.SerialTransport.disconnect = MagicMock()
-
-    # Mock the calls we interested in
-    publish_mock = asyncio_mqtt.client.Client.publish = AsyncMock()
-    recv_mock = iec62056_21.transports.SerialTransport._recv = MagicMock()
-    send_mock = iec62056_21.transports.SerialTransport._send = MagicMock()
-
-    # Simulate data received from serial port.
-    recv_mock.side_effect = [
-        # Accessing `bytes` by subscription or via iterator (what `side_effect`
-        # internally does for iterable) will result in integer, so to retain
-        # the type the nested arrays each containing single `bytes` is used
-        bytes([y]) for y in
-        # Produces array of bytes of all serial exchange fragments
-        reduce(
-            lambda x, y: x + y,
-            [x['send_bytes'] for x in serial_exchange]
-        )
-    ]
-
-    # Instantiate the client
     config_yaml = '''
         general:
             oneshot: true
         meter:
           port: dummy_serial
           password: dummy
+          timeout: 1
         mqtt:
           host: mqtt_dummy_host
           user: mqtt_dummy_user
@@ -954,13 +970,57 @@ def run_main():
     # Perform communication with the device and issue MQTT calls
     with patch('builtins.open', mock_open(read_data=config_yaml)):
         with patch.object(sys, 'argv', ['dummy']):
-            main.main()
+            return main.main()
 
+
+@freeze_time("2022-05-01")
+# Mock the calls we interested in
+@patch.object(asyncio_mqtt.client.Client, 'publish')
+@patch.object(iec62056_21.transports.SerialTransport, '_send')
+@patch.object(iec62056_21.transports.SerialTransport, '_recv')
+# Mock certain methods of 'iec62056_21' package (serial communications) and
+# 'asyncio_mqtt' (MQTT) to prevent serial/networking calls
+@patch.object(iec62056_21.transports.SerialTransport, 'switch_baudrate')
+@patch.object(iec62056_21.transports.SerialTransport, 'disconnect')
+@patch.object(iec62056_21.transports.SerialTransport, 'connect')
+@patch.object(asyncio_mqtt.client.Client, 'connect')
+def run_main_with_mocks(
+    _mqtt_connect_mock, _serial_connect_mock, _serial_disconnect_mock,
+    _serial_switch_baudrate_mock,
+    serial_recv_mock, serial_send_mock, mqtt_publish_mock,
+    simulate_timeout=False
+):
+    '''
+    Execute the main flow interacting with the device and MQTT.
+    '''
+
+    # Simulate data received from serial port.
+    mocked_serial_exchange = [
+        # Accessing `bytes` by subscription or via iterator (what `side_effect`
+        # internally does for iterable) will result in integer, so to retain
+        # the type the nested arrays each containing single `bytes` is used
+        bytes([y]) for y in
+        # Produces array of bytes of all serial exchange fragments
+        reduce(
+            lambda x, y: x + y,
+            [x['send_bytes'] for x in serial_exchange]
+        )
+    ]
+
+    if simulate_timeout:
+        # Simulate timeout occured at the end of mocked serial exchange. Some
+        # initial packets are needed to grab meter identification so we can
+        # test online sensor (it depends on those)
+        mocked_serial_exchange[-1] = TimeoutError
+
+    serial_recv_mock.side_effect = mocked_serial_exchange
+
+    run_main()
     # Resulting calls sending data over serial and doing MQTT publishes
-    return publish_mock.call_args_list, send_mock.call_args_list
+    return mqtt_publish_mock.call_args_list, serial_send_mock.call_args_list
 
 
-(mqtt_publish_call_args, serial_send_call_args) = run_main()
+(mqtt_publish_call_args, serial_send_call_args) = run_main_with_mocks()
 
 
 def generate_mqtt_tests(call_args):
@@ -973,7 +1033,7 @@ def generate_mqtt_tests(call_args):
     ids = []
     for (exp, arg) in zip(mqtt_publish_calls, call_args):
         values.append((arg, exp))
-        ids.append(exp.args[0])
+        ids.append(exp.kwargs.get('topic', str(exp)))
 
     return {'argvalues': values, 'ids': ids}
 
@@ -1012,3 +1072,37 @@ def test_mqtt_publish(mqtt_call, mqtt_expected):
     Tests the data published to MQTT.
     '''
     assert mqtt_call == mqtt_expected
+
+
+@patch.object(asyncio_mqtt.client.Client, 'publish')
+@patch.object(asyncio_mqtt.client.Client, 'connect')
+@patch.object(iec62056_21.transports.SerialTransport, '_recv')
+@patch.object(iec62056_21.transports.SerialTransport, '_send')
+@patch.object(iec62056_21.transports.SerialTransport, 'connect')
+def test_timeout(_serial_connect_mock, _serial_send_mock,
+                 serial_recv_mock, _mqtt_connect_mock, _mqtt_publish_mock):
+    '''
+    Tests for timeout handling.
+    '''
+    serial_recv_mock.return_value = None
+    run_main()
+
+
+def test_online_sensor():
+    '''
+    Tests for handling pseudo online sensor under timeout condition.
+    '''
+    (mqtt_publish_call_args_for_timeout, _) = run_main_with_mocks(
+        simulate_timeout=True
+    )
+
+    assert call(
+        topic='homeassistant/binary_sensor/CE301_00123456'
+        '/CE301_00123456_IS_ONLINE/state',
+        payload=json.dumps({'value': 'off'}),
+        will=dict(
+            topic='homeassistant/binary_sensor/CE301_00123456'
+            '/CE301_00123456_IS_ONLINE/state',
+            payload=json.dumps({'value': 'off'}),
+        ),
+    ) in mqtt_publish_call_args_for_timeout

--- a/tests/test_online_sensor.py
+++ b/tests/test_online_sensor.py
@@ -106,7 +106,7 @@ def mqtt_broker():
     ]
     config_str = "\n".join(config)
 
-    with tempfile.TemporaryDirectory() as tmpdir:
+    with tempfile.TemporaryDirectory(dir=os.getenv('RUNNER_TEMP')) as tmpdir:
         print(f'Using {tmpdir} as temporary directory')
         mqtt_config_file = os.path.join(tmpdir, 'mosquitto.conf')
         with open(mqtt_config_file, 'w', encoding='ascii') as mqtt_config:

--- a/tests/test_online_sensor.py
+++ b/tests/test_online_sensor.py
@@ -31,7 +31,7 @@ import docker
 import pytest
 from energomera_hass_mqtt.mqtt_client import MqttClient
 from energomera_hass_mqtt.main import async_main, main
-from tests.test_energomera import mock_serial, mock_mqtt, mock_config
+from test_energomera import mock_serial, mock_mqtt, mock_config
 
 
 # pylint: disable=too-few-public-methods

--- a/tests/test_online_sensor.py
+++ b/tests/test_online_sensor.py
@@ -106,7 +106,10 @@ def mqtt_broker():
     ]
     config_str = "\n".join(config)
 
-    with tempfile.TemporaryDirectory(dir=os.getenv('RUNNER_TEMP')) as tmpdir:
+    with tempfile.TemporaryDirectory(
+        dir=os.getenv('RUNNER_TEMP'),
+        ignore_cleanup_errors=True
+    ) as tmpdir:
         print(f'Using {tmpdir} as temporary directory')
         mqtt_config_file = os.path.join(tmpdir, 'mosquitto.conf')
         with open(mqtt_config_file, 'w', encoding='ascii') as mqtt_config:

--- a/tests/test_online_sensor.py
+++ b/tests/test_online_sensor.py
@@ -69,8 +69,14 @@ class MqttClientTimedSubscribe(MqttClient):
             Asynchronous generator that sends messages from the queue received
             within configured time interval
             '''
+            try:
+                asyncio_create_task = asyncio.create_task
+            except AttributeError:
+                # Python 3.6 has no `asyncio.create_task`
+                asyncio_create_task = asyncio.ensure_future
+
             while True:
-                task = asyncio.create_task(messages.get())
+                task = asyncio_create_task(messages.get())
                 done, _ = await asyncio.wait(
                     [task], timeout=self._subscribe_timeout
                 )

--- a/tests/test_online_sensor.py
+++ b/tests/test_online_sensor.py
@@ -1,0 +1,205 @@
+# Copyright (c) 2022 Ilia Sotnikov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+'''
+Tests for online sensor behavior
+'''
+import os
+import tempfile
+import asyncio
+import time
+import json
+from unittest.mock import patch, call
+import docker
+import pytest
+from energomera_hass_mqtt.mqtt_client import MqttClient
+from energomera_hass_mqtt.main import async_main, main
+from tests.test_energomera import mock_serial, mock_mqtt, mock_config
+
+
+# pylint: disable=too-few-public-methods
+class MqttClientTimedSubscribe(MqttClient):
+    '''
+    MQTT client with timed subscribe functionality - that is, allowing to
+    received messages from subscription within configured time frame. The
+    existing MQTT client, in contrast, awaits for the messages indefinitely
+
+    :param int subscribe_timeout: Time interval to wait for messages coming
+     from MQTT subscription
+    :param list *args: Pass through positional arguments
+    :param dict *kwargs: Pass trhough keyword arguments
+    '''
+    def __init__(self, subscribe_timeout, *args, **kwargs):
+        self._subscribe_timeout = subscribe_timeout
+        super().__init__(*args, **kwargs)
+
+    def _cb_and_generator(self, *_args, **_kwargs):
+        '''
+        Overrides the method providing callback for messages received from
+        subscription and sending them to the caller from async generator.
+        '''
+        messages = asyncio.Queue()
+
+        def _put_in_queue(_client, _userdata, msg):
+            '''
+            MQTT callback that simply puts received messages to the queue
+            '''
+            messages.put_nowait(msg)
+
+        async def _generator():
+            '''
+            Asynchronous generator that sends messages from the queue received
+            within configured time interval
+            '''
+            while True:
+                task = asyncio.create_task(messages.get())
+                done, _ = await asyncio.wait(
+                    [task], timeout=self._subscribe_timeout
+                )
+                # Stop processing messages if configured internal has elapsed
+                if task not in done:
+                    task.cancel()
+                    break
+                # Provide received message to the caller
+                yield task.result()
+
+        return _put_in_queue, _generator()
+
+
+@pytest.fixture(scope='session')
+def mqtt_broker():
+    '''
+    Fixture provisioning MQTT broker in form of Docker container
+    '''
+    client = docker.DockerClient()
+
+    port = 1883
+    # Broker configuration file
+    config = [
+        f'listener {port}',
+        'allow_anonymous true',
+        'log_type debug',
+        'log_type error',
+        'log_type warning',
+        'log_type notice',
+        'log_type information',
+        'log_dest stdout',
+        'connection_messages true',
+        ''
+    ]
+    config_str = "\n".join(config)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        print(f'Using {tmpdir} as temporary directory')
+        mqtt_config_file = os.path.join(tmpdir, 'mosquitto.conf')
+        with open(mqtt_config_file, 'w', encoding='ascii') as mqtt_config:
+            mqtt_config.write(config_str)
+
+        container = client.containers.run(
+            'eclipse-mosquitto', detach=True,
+            remove=True,
+            ports={f'{port}/tcp': (None, port)},
+            volumes={tmpdir: {'bind': '/mosquitto/config'}},
+        )
+        # Allow the broker to startup and ready for the clients
+        time.sleep(1)
+
+        # Pass the execution to the test using the fixture
+        yield
+        # Clean the container up once the test completes
+        container.stop()
+
+
+@pytest.mark.asyncio
+async def test_online_sensor_last_will(
+    # `pylint` mistekenly treats fixture as re-definition
+    # pylint: disable=redefined-outer-name, unused-argument
+    mqtt_broker
+):
+    '''
+    Tests online sensor for properly utilizing MQTT last will to set the state
+    if the code doesn't disconnect cleanly
+    '''
+    async def mqtt_client_destroy(self):
+        '''
+        Function to shutdown MQTT client sockets instead of doing clean
+        disconnect
+        '''
+        # This triggers call to `_reset_sockets()` in Paho MQTT
+        del self._client
+        # Re-instantiate fresh Paho MQTT client so Async MQTT won't trip over
+        # missing `_client` attribute
+        # pylint: disable=protected-access
+        self._client = MqttClient(hostname='dummy')._client
+
+    with mock_config():
+        with mock_serial():
+            # Replace MQTT disconnect with the function to forcibly shutdown
+            # MQTT client sockets, simulating unclean disconnect
+            with patch.object(MqttClient, 'disconnect', mqtt_client_destroy):
+                # Setup MQTT keep-alive to a minimal value, so that unclean
+                # disconnect will result in last will message being sent upon
+                # keep-alive elapses
+                with patch.object(MqttClient, '_keepalive', 1):
+                    await async_main()
+
+    # Use MQTT client that allows for receiving MQTT messages over configured
+    # time interval, to avoid blocking execution indefinitely (as parent MQTT
+    # client does)
+    mqtt_client = MqttClientTimedSubscribe(
+        # Timeout value should be sufficiently longer that keep-alive interval
+        # above, so that last will feature will be activated
+        hostname='127.0.0.1', subscribe_timeout=5
+    )
+
+    # Attempt to receive online sensor state upon unclean shutdown of the MQTT
+    # client
+    async with mqtt_client as client:
+        async with client.unfiltered_messages() as messages:
+            await client.subscribe('homeassistant/binary_sensor/+/+/state', 0)
+            online_sensor_state = [
+                x.payload.decode() async for x in messages
+                if 'IS_ONLINE' in x.topic
+            ]
+            # Verify only single message received
+            assert len(online_sensor_state) == 1
+            # Verify the sensor state should be OFF during unclean shutdown
+            assert online_sensor_state.pop() == json.dumps({'value': 'OFF'})
+
+
+def test_online_sensor():
+    '''
+    Tests for handling pseudo online sensor under timeout condition.
+    '''
+
+    mqtt_publish_call_args_for_timeout = []
+    with mock_serial(simulate_timeout=True):
+        with mock_mqtt() as mqtt_mocks:
+            with mock_config():
+                main()
+                mqtt_publish_call_args_for_timeout = (
+                    mqtt_mocks['publish'].call_args_list
+                )
+
+    assert call(
+        topic='homeassistant/binary_sensor/CE301_00123456'
+        '/CE301_00123456_IS_ONLINE/state',
+        payload=json.dumps({'value': 'OFF'}),
+    ) in mqtt_publish_call_args_for_timeout

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ commands =
     pylint --output-format=parseable --output=pylint.txt src/energomera_hass_mqtt
     # Ensure only traces for in-repository module is processed, not for one
     # installed by `tox` (see above for more details)
-    pytest --cov=src/energomera_hass_mqtt --cov-append -v tests
+    pytest --cov=src/energomera_hass_mqtt --cov-append -v -s tests
 commands_post =
 	# Show the `pylint` report to the standard output, to ease fixing the issues reported
 	cat pylint.txt

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ deps =
 	pytest-cov
 	mock;python_version<"3.8"
 	freezegun
+	docker
 setenv =
 	# Ensure the module under test will be found under `src/` directory, in
 	# case of any test command below will attempt importing it. In particular,

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,9 @@ setenv =
 	# from the module installed by `tox` in the virtual environment (the traces
 	# will be referencing `tox` specific paths, not aligned with repository)
     PYTHONPATH = src
+passenv =
+	RUNNER_*
+	GITHUB_*
 allowlist_externals =
 	cat
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ deps =
 	pylint
 	pytest
 	pytest-cov
+	pytest-asyncio
 	mock;python_version<"3.8"
 	freezegun
 	docker


### PR DESCRIPTION
* Added support for `meter.timeout` configuration parameter to control timeout communicating with the meter
* Allowed to control TLS for MQTT broker connections via `mqtt.tls`  configuration parameter
* `src/energomera_hass_mqtt/__init__.py`:
  * Added `IecToHassSensor.iec_item` property and `IecToHassSensor.hass_config_payload()`, `IecToHassSensor.hass_state_payload()` methods providing associated IEC  item, config and state payloads for HASS, respectively, for better  extensibility
  * Added `IecToHassBinarySensor` class that extends `IecToHassSensor` and reflect specific of HASS binary sensor
  * Added `PseudoBinarySensor` class extending `IecToHassBinarySensor` to  allow constructing binary sensors not present on the meter
  * Added implementation for `meter.timeout` configuration option
  * Added `EnergomeraHassMqtt.set_online_sensor()` method that is  called from `EnergomeraHassMqtt.iec_read_admin()` with sensor value   being `True` if the latter completes successfully, and `False` if it  receives `TimeoutError` from underlying code (mainly from IEC related  calls). The pseudo binary sensor will also send `False` as its state  if MQTT client disconnects uncleanly (using last will mechanism)
   * `IecToHassSensor.process()`: Added `setup_only` parameter to perform  only setup steps for the entry, such as determining MQTT topics etc., with no payloads sent to MQTT. Used to configure MQTT last will, since  it has to be done prior to connecting to MQTT broker, thus no payloads could be sent yet
    * `IecToHassSensor.process()`: Publishing MQTT payloads now uses MQTT  client already connected to the broker, reducing amount of connect/disconnect operations
    * `EnergomeraHassMqtt`: Both serial and MQTT clients are disconnected as a part of finalization code when current handling cycle is completed
* `tests/test_energomera.py`:
  * Added tests for simulated timeouts  communicating with meter - simulated no meter responses, and a timeout  happening at the end of communication, the latter is tested for online sensor being sent over MQTT to HASS
  * Mocking interfaces reworked to context managers, since it makes code cleaner
  * Mocked config is adjusted to be suitable for Docker-based tests with  the broker running in container
  * Mocked config has got interpolations, thus use of `freezegun`,  removed - those are tested separately. Freezing time leads to MQTT  connections timing out when being executed against real broker (i.e. not mocked)
* Added tests for online sensor, including interaction with real MQTT  broker (provisioned as Docker container) and unclean client shutdown  to verify last will functionality
* `src/energomera_hass_mqtt/main.py`: Improved logging by moving to `logging` and leveraging its ability to report exception traceback
*  Added `mqtt_client.MqttClient` class that extends   `asyncio_mqtt.client.Client` with better convenience working with last   will
