### PR TITLE
Fixed processing for online sensor

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,8 @@ Configuration file is in YAML format and supports following elements:
             #  exit
             oneshot:
             # (number) default ``30``: delay in seconds between processing
-            #  cycles
+            #  cycles. Is also used as MQTT keepalive interval upon which the
+            #  broker will consider the client disconnected if no response
             intercycle_delay:
             # (string) default ``error``: logging level, one of ``critical``,
             #  ``error``, ``warning``, ``info`` or ``debug``
@@ -89,6 +90,8 @@ Configuration file is in YAML format and supports following elements:
             # (string) default ``homeassistant``: Preffix to MQTT topic names,
             #  should correspond to one set in HomeAssistant for auto-discovery
             hass_discovery_prefix:
+            # (bool) default ``true``: Whether to enable TLS with MQTT broker
+            tls:
         # (list of mappings) - optional: Energy meter parameters to process and
         #  properties of corresponding HASS sensor
         parameters:
@@ -139,6 +142,13 @@ There are Docker images available if you would like to run it as Docker containe
 ``ghcr.io/hostcc/energomera-hass-mqtt:<release version>``.
 
 As of writing, the images are built to ARM v6/v7 and ARM64 platforms.
+
+.. note::
+
+   For ARMv6 you might need to specify image variant explicitly, in case the
+   container engine detects it incorrectly and resulting image doesn't run as
+   expected. To do that just add ``--variant v6`` to ``pull`` command
+
 
 To run the program as container you will need to create a directory on the host
 and put ``config.yaml`` relevant to your setup there.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,10 @@ pythonpath = [
 log_cli = 1
 log_cli_level = "error"
 
+markers = [
+    "mqtt_broker_users",
+]
+
 [tool.pylint.main]
 load-plugins = "pylint.extensions.no_self_use"
 

--- a/src/energomera_hass_mqtt/main.py
+++ b/src/energomera_hass_mqtt/main.py
@@ -64,6 +64,7 @@ async def async_main():
         if config.of.general.oneshot:
             break
         await asyncio.sleep(config.of.general.intercycle_delay)
+    await client.finalize()
 
 
 def main():

--- a/src/energomera_hass_mqtt/mqtt_client.py
+++ b/src/energomera_hass_mqtt/mqtt_client.py
@@ -50,6 +50,20 @@ class MqttClient(asyncio_mqtt.Client):
             kwargs['keepalive'] = self._keepalive
         super().__init__(logger=_LOGGER, *args, **kwargs)
 
+    async def connect(self, *args, **kwargs):
+        """
+        Connects to MQTT broker.
+        Multiple calls will result only in single call to `connect()` method of
+        parent class, to allow the method to be called within a process loop
+        with no risk of constantly reinitializing MQTT broker connection.
+
+        :param args: Pass-through positional arguments for parent class
+        :param kwargs: Pass-through keyword arguments for parent class
+
+        """
+        if not self._connected.done():
+            await super().connect(*args, *kwargs)
+
     def will_set(self, *args, **kwargs):
         """
         Allows setting last will to the underlying MQTT client.

--- a/tests/test_online_sensor.py
+++ b/tests/test_online_sensor.py
@@ -239,7 +239,8 @@ async def test_online_sensor_normal_run(
     mqtt_broker
 ):
     '''
-    Tests online sensor for properly reflecting online sensors state during normal run
+    Tests online sensor for properly reflecting online sensors state during
+    normal run
     '''
 
     # Use MQTT client that allows for receiving MQTT messages over configured

--- a/tests/test_online_sensor.py
+++ b/tests/test_online_sensor.py
@@ -239,8 +239,7 @@ async def test_online_sensor_normal_run(
     mqtt_broker
 ):
     '''
-    Tests online sensor for properly utilizing MQTT last will to set the state
-    if the code doesn't disconnect cleanly
+    Tests online sensor for properly reflecting online sensors state during normal run
     '''
 
     # Use MQTT client that allows for receiving MQTT messages over configured
@@ -252,8 +251,7 @@ async def test_online_sensor_normal_run(
         hostname='127.0.0.1', subscribe_timeout=5,
     )
 
-    # Attempt to receive online sensor state upon unclean shutdown of the MQTT
-    # client
+    # Attempt to receive online sensor state upon normal program run
     async with mqtt_client as client:
         async with client.unfiltered_messages() as messages:
             await client.subscribe('homeassistant/binary_sensor/+/+/state', 0)
@@ -266,9 +264,10 @@ async def test_online_sensor_normal_run(
                 x.payload.decode() async for x in messages
                 if 'IS_ONLINE' in x.topic
             ]
-            # Verify only single message received
+            # There should be two messages for online sensor - first with 'ON'
+            # value during the program run, and another with 'OFF' value
+            # generated at program exit
             assert len(online_sensor_state) == 2
-            # Verify the sensor state should be OFF during unclean shutdown
             assert online_sensor_state == [
                 json.dumps({'value': 'ON'}),
                 json.dumps({'value': 'OFF'})


### PR DESCRIPTION
## Fixed processing online sensor to properly reflect its state
If no MQTT   responses are seen from the clients for more than `config.general.intercycle_delay` the client will be considered  disconnected and last will be be sent indicating online state being  'off'. Previously, each cycle of interacting with meter had pair of  `connect`/`disconnect` MQTT client calls so last will is not activated  if the program dies in between invocations.
* Introduced `MqttClient.connect()` method that supports multiple   calls to it while performing actual connect only once (if underlying  MQTT client isn't connected already)
* Added `EnergomeraHassMqtt.finalize()` method that is now performs  MQTT client disconnect only at the end of processing, when the  program is about to exit
* Set MQTT keepalive to interval between meter interaction cycles (`config.general.intercycle_delay`), so that MQTT broker will  consider the client disconnected upon that internal if no MQTT  traffic is seen from the client.  Please note the interval could be  shorter due to the use of `asyncio_mqtt`, since its asynchronous task runs in the loop and can respond to MQTT pings anytime in between meter cycles.

##  `tests/test_online_sensor`: Tests adjusted to cover normal program run  against real MQTT broker
* The MQTT broker fixture now supports managing users/password via `pytest` mark `mqtt_broker_users` (currently unused)
* Added `test_online_sensor_normal_run` test that performs normal  program run against real MQTT broker and validates proper online sensor states are sent

## `README.rst` updates
*  Added mentions of explicit Docker image variant if it isn't selected  properly (seems happening with ARMv6 only)
* Added documentation for `config.mqtt.tls` property
* Added clarification to `config.general.intercycle_delay` is also  used as MQTT keepalive interval