### PR TITLE
Fixed (re)connecting to MQTT broker if no active connection exists or one got disconnected

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,26 +16,26 @@ isolated_build = true
 deps =
     check-manifest >= 0.42
     flake8
-	pylint
-	pytest
-	pytest-cov
-	pytest-asyncio
-	mock;python_version<"3.8"
-	freezegun
-	docker
+    pylint
+    pytest
+    pytest-cov
+    pytest-asyncio
+    mock;python_version<"3.8"
+    freezegun
+    docker
 setenv =
-	# Ensure the module under test will be found under `src/` directory, in
-	# case of any test command below will attempt importing it. In particular,
-	# it helps `coverage` to recognize test traces from the module under `src/`
-	# directory and report correct (aligned with repository layout) paths, not
-	# from the module installed by `tox` in the virtual environment (the traces
-	# will be referencing `tox` specific paths, not aligned with repository)
+    # Ensure the module under test will be found under `src/` directory, in
+    # case of any test command below will attempt importing it. In particular,
+    # it helps `coverage` to recognize test traces from the module under `src/`
+    # directory and report correct (aligned with repository layout) paths, not
+    # from the module installed by `tox` in the virtual environment (the traces
+    # will be referencing `tox` specific paths, not aligned with repository)
     PYTHONPATH = src
 passenv =
-	RUNNER_*
-	GITHUB_*
+    RUNNER_*
+    GITHUB_*
 allowlist_externals =
-	cat
+    cat
 commands =
     check-manifest --ignore 'tox.ini,tests/**,docs/**,.pylintrc,.readthedocs.yaml,sonar-project.properties,systemd/**',Dockerfile
     flake8 --tee --output-file=flake8.txt .
@@ -44,8 +44,8 @@ commands =
     # installed by `tox` (see above for more details)
     pytest --cov=src/energomera_hass_mqtt --cov-append -v -s tests
 commands_post =
-	# Show the `pylint` report to the standard output, to ease fixing the issues reported
-	cat pylint.txt
+    # Show the `pylint` report to the standard output, to ease fixing the issues reported
+    cat pylint.txt
 
 [flake8]
 exclude = .tox,*.egg,build,data,scripts,docs


### PR DESCRIPTION
Previously, only connected state of MQTT connection has been used as triggering condition of performing actual connect, and that doesn't reflect the fact active connection got disconnected.