### PR TITLE
Interpolation expression arguments

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,9 @@ jobs:
           - os: ubuntu-latest
             python: '3.10'
             toxenv: py
+          - os: ubuntu-latest
+            python: '3.11'
+            toxenv: py
     runs-on: ${{ matrix.os }}
     outputs:
       version: ${{ steps.package-version.outputs.VALUE }}

--- a/README.rst
+++ b/README.rst
@@ -121,10 +121,25 @@ Configuration file is in YAML format and supports following elements:
               response_idx:
 
 
+Interpolation expressions
+-------------------------
+
 ``parameters`` section supports following expressions:
 
-        - ``{{ energomera_prev_month }}``: Previous month in meter's format
-        - ``{{ energomera_prev_day }}``: Previous day in meter's format
+        - ``{{ energomera_prev_month }}``: Previous month in meter's format,
+          defaults to one month back
+        - ``{{ energomera_prev_day }}``: Previous day in meter's format,
+          default to one day back
+
+All expressions support passing optional argument as ``(...)`` to specify how far
+interpolated result should go in the past. Whitespaces around the brackets,
+both inner and outer, are ignored. Specifying empty argument results in
+using a default value as per interpolation specification above.
+
+For example, ``{{ energomera_prev_day (5) }}`` will result in meter-specific
+timestamp returned for the date being 5 days ago. An use case for that might be
+intermittent connectivity to the meter where the readings aren't sent to
+collecting system on cadence thus have gaps in data points.
 
 
 ``systemd`` support

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ install_requires =
 	asyncio-mqtt==0.16.1
 	pyyaml==6.0
 	schema==0.7.5
+	python-dateutil==2.8.2
 
 [options.packages.find]
 where = src

--- a/src/energomera_hass_mqtt/config.py
+++ b/src/energomera_hass_mqtt/config.py
@@ -59,6 +59,10 @@ class EnergomeraConfig:
         :return str: Interpolated value for the expression argument
         :rtype: str
         """
+        # The method is designed to be called by `re.sub`, protect from being
+        # called directly with no re.Match instance provided
+        assert match is not None
+
         try:
             expr = match.group(0)
             arg = match.group(1)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -168,6 +168,34 @@ def config_with_interpolations():
               state_class: dummy_state
               unit: dummy
               additional_data: '{{ energomera_prev_day }}'
+            # Argument specifying 5 months ago
+            - name: dummy_param3
+              address: dummy_addr1
+              device_class: dummy_class
+              state_class: dummy_state
+              unit: dummy
+              additional_data: '{{ energomera_prev_month (5) }}'
+            # Argument specifying 2 days ago
+            - name: dummy_param4
+              address: dummy_addr1
+              device_class: dummy_class
+              state_class: dummy_state
+              unit: dummy
+              additional_data: '{{ energomera_prev_day (2) }}'
+            # Empty argument that falls back to 1 month ago
+            - name: dummy_param5
+              address: dummy_addr1
+              device_class: dummy_class
+              state_class: dummy_state
+              unit: dummy
+              additional_data: '{{ energomera_prev_month () }}'
+            # Empty argument with whitespaces only that falls back to 1 day ago
+            - name: dummy_param6
+              address: dummy_addr1
+              device_class: dummy_class
+              state_class: dummy_state
+              unit: dummy
+              additional_data: '{{ energomera_prev_day ( ) }}'
     '''
 
     with patch('builtins.open', mock_open(read_data=interpolated_config_yaml)):
@@ -175,16 +203,20 @@ def config_with_interpolations():
     return config
 
 
-@pytest.mark.parametrize('frozen_date,prev_month,prev_day', [
-    ('2022-05-01', '04.22', '30.04.22'),
-    ('2022-05-10', '04.22', '09.05.22'),
-    ('2022-06-01', '05.22', '31.05.22'),
-    ('2023-01-01', '12.22', '31.12.22'),
-])
+@pytest.mark.parametrize(
+    'frozen_date,prev_month,prev_day,older_month,older_day',
+    [
+        ('2022-05-01', '04.22', '30.04.22', '12.21', '29.04.22'),
+        ('2022-05-10', '04.22', '09.05.22', '12.21', '08.05.22'),
+        ('2022-06-01', '05.22', '31.05.22', '01.22', '30.05.22'),
+        ('2023-01-01', '12.22', '31.12.22', '08.22', '30.12.22'),
+    ]
+)
 def test_config_interpolation_date_change(
     # `pylint` mistekenly treats fixture as re-definition
-    # pylint: disable=redefined-outer-name
-    config_with_interpolations, frozen_date, prev_month, prev_day
+    # pylint: disable=redefined-outer-name,too-many-arguments
+    config_with_interpolations, frozen_date,
+    prev_month, prev_day, older_month, older_day
 ):
     '''
     Verifies for interpolated expressions properly processed when `interpolate`
@@ -202,3 +234,76 @@ def test_config_interpolation_date_change(
             .of.parameters[1]
             .additional_data == prev_day
         )
+        assert (
+            config_with_interpolations
+            .of.parameters[2]
+            .additional_data == older_month
+        )
+        assert (
+            config_with_interpolations
+            .of.parameters[3]
+            .additional_data == older_day
+        )
+        assert (
+            config_with_interpolations
+            .of.parameters[4]
+            .additional_data == prev_month
+        )
+        assert (
+            config_with_interpolations
+            .of.parameters[5]
+            .additional_data == prev_day
+        )
+
+
+@pytest.fixture
+def config_with_invalid_interpolations():
+    '''
+    Provides configuration object with interpolation expressions having invalid
+    argument specified.
+    '''
+    interpolated_config_yaml = '''
+        meter:
+          port: dummy_serial
+          password: dummy_password
+        mqtt:
+          host: a_mqtt_host
+          user: a_mqtt_user
+          password: mqtt_dummy_password
+        parameters:
+            # Argument with closing bracket missing
+            - name: dummy_param1
+              address: dummy_addr1
+              device_class: dummy_class
+              state_class: dummy_state
+              unit: dummy
+              additional_data: '{{ energomera_prev_day ( }}'
+            # Argument with opening bracket missing
+            - name: dummy_param2
+              address: dummy_addr1
+              device_class: dummy_class
+              state_class: dummy_state
+              unit: dummy
+              additional_data: '{{ energomera_prev_day ) }}'
+            # Non-numeric argument
+            - name: dummy_param3
+              address: dummy_addr1
+              device_class: dummy_class
+              state_class: dummy_state
+              unit: dummy
+              additional_data: '{{ energomera_prev_day (non-numeric) }}'
+    '''
+    with patch('builtins.open', mock_open(read_data=interpolated_config_yaml)):
+        config = EnergomeraConfig(config_file='dummy')
+    return config
+
+
+# `pylint` mistekenly treats fixture as re-definition
+# pylint: disable=redefined-outer-name
+def test_config_interpolation_invalid(config_with_invalid_interpolations):
+    '''
+    Verifies the expression interpolation raises exception processing the
+    argument having invalid format.
+    '''
+    with pytest.raises(EnergomeraConfigError):
+        config_with_invalid_interpolations.interpolate()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310}
+envlist = py{37,38,39,310,311}
 
 # Define the minimal tox version required to run;
 # if the host tox is less than this the tool with create an environment and
@@ -44,7 +44,7 @@ commands =
     pylint --output-format=parseable --output=pylint.txt src/energomera_hass_mqtt
     # Ensure only traces for in-repository module is processed, not for one
     # installed by `tox` (see above for more details)
-    pytest --cov=src/energomera_hass_mqtt --cov-append -v -s tests
+    pytest --cov=src/energomera_hass_mqtt --cov-append -v --cov-report=term-missing -s tests []
 commands_post =
     # Show the `pylint` report to the standard output, to ease fixing the issues reported
     cat pylint.txt


### PR DESCRIPTION
* Added support for all configuration expressions to have optional  argument as ``(...)`` to specify how far interpolated result should go  in the past. Whitespaces around the brackets, both inner and outer,  are ignored. Specifying empty argument results in using a default  value as per interpolation specification (typically one date unit,  such as single day or month)

  For example, ``{{ energomera_prev_day (5) }}`` will result in  meter-specific timestamp returned for the date being 5 days ago. An  use case for that might be intermittent connectivity to the meter  where the readings aren't sent to collecting system on cadence thus  have gaps in data points.

* Added testing with Python 3.11