### PR TITLE
Allow including default parameters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,10 @@ Configuration file is in YAML format and supports following elements:
             # (string) default ``error``: logging level, one of ``critical``,
             #  ``error``, ``warning``, ``info`` or ``debug``
             logging_level:
-
+            # (bool) default ``false``: if enabled makes parameters a
+            # combination of default ones plus those defined in the
+            # configuration file, no check for duplicates is performed!
+            include_default_parameters:
         # Energy meter parameters
         meter:
             # (string) Serial port (e.g. /dev/ttyUSB0)

--- a/src/energomera_hass_mqtt/config.py
+++ b/src/energomera_hass_mqtt/config.py
@@ -221,8 +221,9 @@ class EnergomeraConfig:
         # Store the configuration state as `addict.Dict` so access by (possibly
         # chained) attributes is available
         self._config = Dict(config)
-        # If enabled makes parameters a combination of default ones plus those defined
-        # in the configuration file, no check for duplicates is performed!
+        # If enabled makes parameters a combination of default ones plus those
+        # defined in the configuration file, no check for duplicates is
+        # performed!
         if self._config.general.include_default_parameters:
             self._config.parameters = (
                 DEFAULT_CONFIG.parameters + self._config.parameters

--- a/src/energomera_hass_mqtt/config.py
+++ b/src/energomera_hass_mqtt/config.py
@@ -156,6 +156,10 @@ class EnergomeraConfig:
                     error='Invalid logging level - should be one of'
                           f' {", ".join(self._logging_levels.keys())}'
                 ),
+                Optional(
+                    'include_default_parameters',
+                    default=DEFAULT_CONFIG.general.include_default_parameters
+                ): bool,
             }),
             'meter': {
                 'port': str,
@@ -213,9 +217,16 @@ class EnergomeraConfig:
             raise EnergomeraConfigError(
                 f'Error validating configuration file:\n{str(exc)}'
             ) from None
+
         # Store the configuration state as `addict.Dict` so access by (possibly
-        # chained) attributes is avavilable
+        # chained) attributes is available
         self._config = Dict(config)
+        # If enabled makes parameters a combination of default ones plus those defined
+        # in the configuration file, no check for duplicates is performed!
+        if self._config.general.include_default_parameters:
+            self._config.parameters = (
+                DEFAULT_CONFIG.parameters + self._config.parameters
+            )
         # Make a copy of the original configuration for the `interpolate()`
         # method to access initially defined interpolation expressions if any
         self._orig_config = deepcopy(self._config)

--- a/src/energomera_hass_mqtt/const.py
+++ b/src/energomera_hass_mqtt/const.py
@@ -31,6 +31,7 @@ DEFAULT_CONFIG = Dict(
         oneshot=False,
         intercycle_delay=30,
         logging_level='error',
+        include_default_parameters=False,
     ),
     meter=dict(
         timeout=30,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -54,6 +54,7 @@ def test_valid_config_file():
             'oneshot': False,
             'intercycle_delay': 30,
             'logging_level': 'error',
+            'include_default_parameters': False,
         },
         'meter': {
             'port': 'dummy_serial',
@@ -86,6 +87,39 @@ def test_valid_config_file():
         assert isinstance(config.of, dict)
         assert config.of == valid_config
         assert config.logging_level == logging.ERROR
+
+
+def test_valid_config_file_with_default_parameters():
+    '''
+    Tests for processing of valid configuration file that allows including
+    default parameters plus adds some custom ones.
+    '''
+    valid_config_yaml = '''
+        general:
+          include_default_parameters: true
+        meter:
+          port: dummy_serial
+          password: dummy_password
+        mqtt:
+          host: a_mqtt_host
+          user: a_mqtt_user
+          password: mqtt_dummy_password
+        parameters:
+            - name: dummy_param
+              address: dummy_addr
+              device_class: dummy_class
+              state_class: dummy_state
+              unit: dummy
+    '''
+
+    with patch('builtins.open', mock_open(read_data=valid_config_yaml)):
+        config = EnergomeraConfig(config_file='dummy')
+        assert isinstance(config.of, dict)
+        # Resulting number of parameters should be combined across default and
+        # custom ones
+        assert len(config.of.parameters) == 12
+        # Verify the last parameter is the custom one
+        assert config.of.parameters[-1].name == 'dummy_param'
 
 
 def test_empty_file():


### PR DESCRIPTION
+ Added `general.include_default_parameters` configuration option (defaults to `false) that if enabled makes parameters a combination of default ones plus those defined in the configuration file, no check for duplicates is performed!