### PR TITLE
Prevent `callback_api_version` related error from `paho-mqtt`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,10 @@ python_requires = >=3.7
 install_requires =
 	iec62056-21 @ git+https://github.com/hostcc/iec62056-21.git@feature/transport-improvements
 	addict==2.4.0
-	asyncio-mqtt==0.16.1
+	asyncio-mqtt==0.16.2
+	# Pin `paho-mqtt` to 1.x until migrating to `aiomqtt`, to prevent
+	# https://github.com/sbtinstruments/aiomqtt/issues/289 from occuring
+	paho-mqtt==1.6.1
 	pyyaml==6.0.1
 	schema==0.7.5
 	python-dateutil==2.8.2


### PR DESCRIPTION
* `paho-mqtt` is pinned to 1.x until migrating to `aiomqtt`, to prevent https://github.com/sbtinstruments/aiomqtt/issues/289 from occuring