### PR TITLE
Migrate to `aiomqtt`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -118,13 +118,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-    # Publishing Docker images only happens when a release published out of the
-    # main branch
-    if: >-
-      github.event_name == 'release'
-      && github.event.action == 'published'
-      && (github.event.release.target_commitish == 'main'
-         || github.event.release.target_commitish == 'master')
     steps:
       - name: Checkout the code
         uses: actions/checkout@v3
@@ -149,9 +142,6 @@ jobs:
           platforms: linux/arm/v7,linux/arm/v6,linux/arm64
           push: true
           tags:
-            "ghcr.io/${{ github.repository_owner }}\
-            /${{ github.event.repository.name }}:latest
-
             ghcr.io/${{ github.repository_owner }}\
             /${{ github.event.repository.name }}\
             :${{ needs.tests.outputs.version }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,9 +18,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python: 3.7
-            toxenv: py
-          - os: ubuntu-latest
             python: 3.8
             toxenv: py
           - os: ubuntu-latest
@@ -31,6 +28,9 @@ jobs:
             toxenv: py
           - os: ubuntu-latest
             python: '3.11'
+            toxenv: py
+          - os: ubuntu-latest
+            python: '3.12'
             toxenv: py
     runs-on: ${{ matrix.os }}
     outputs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -142,6 +142,6 @@ jobs:
           platforms: linux/arm/v7,linux/arm/v6,linux/arm64
           push: true
           tags:
-            ghcr.io/${{ github.repository_owner }}\
+            "ghcr.io/${{ github.repository_owner }}\
             /${{ github.event.repository.name }}\
             :${{ needs.tests.outputs.version }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,8 @@ markers = [
 
 [tool.pylint.main]
 load-plugins = "pylint.extensions.no_self_use"
+# Newer `pylint` raises errors on using `dict()`, ignore those for now
+disable = "use-dict-literal"
 
 [tool.pylint.typecheck]
 signature-mutators = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,13 +31,10 @@ python_requires = >=3.7
 install_requires =
 	iec62056-21 @ git+https://github.com/hostcc/iec62056-21.git@feature/transport-improvements
 	addict==2.4.0
-	asyncio-mqtt==0.16.2
-	# Pin `paho-mqtt` to 1.x until migrating to `aiomqtt`, to prevent
-	# https://github.com/sbtinstruments/aiomqtt/issues/289 from occuring
-	paho-mqtt==1.6.1
+	aiomqtt==2.1.0
 	pyyaml==6.0.1
-	schema==0.7.5
-	python-dateutil==2.8.2
+	schema==0.7.7
+	python-dateutil==2.9.0
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,8 @@ python_requires = >=3.7
 install_requires =
 	iec62056-21 @ git+https://github.com/hostcc/iec62056-21.git@feature/transport-improvements
 	addict==2.4.0
-	aiomqtt==2.1.0
+	aiomqtt==2.1.0;python_version>"3.7"
+	aiomqtt==1.1.0;python_version=="3.7"
 	pyyaml==6.0.1
 	schema==0.7.7
 	python-dateutil==2.9.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,22 +17,22 @@ classifiers =
 	Topic :: System :: Hardware
 	License :: OSI Approved :: MIT License
 	Programming Language :: Python :: 3
-	Programming Language :: Python :: 3.7
 	Programming Language :: Python :: 3.8
 	Programming Language :: Python :: 3.9
 	Programming Language :: Python :: 3.10
+	Programming Language :: Python :: 3.11
+	Programming Language :: Python :: 3.12
 	Programming Language :: Python :: 3 :: Only
 
 [options]
 package_dir =
 	= src
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
 	iec62056-21 @ git+https://github.com/hostcc/iec62056-21.git@feature/transport-improvements
 	addict==2.4.0
-	aiomqtt==2.1.0;python_version>"3.7"
-	aiomqtt==1.1.0;python_version=="3.7"
+	aiomqtt==2.1.0
 	pyyaml==6.0.1
 	schema==0.7.7
 	python-dateutil==2.9.0

--- a/src/energomera_hass_mqtt/hass_mqtt.py
+++ b/src/energomera_hass_mqtt/hass_mqtt.py
@@ -166,9 +166,9 @@ class EnergomeraHassMqtt:
             # connecting to the broker
             await self.set_online_sensor(False, setup_only=True)
             # The connection to MQTT broker is instantiated only once, if not
-            # connected previously.  See `MqttClient.connect()` for more
-            # details
-            await self._mqtt_client.connect()
+            # connected previously.
+            # pylint:disable=unnecessary-dunder-call
+            await self._mqtt_client.__aenter__()
             # Process parameters requested
             for param in self._config.of.parameters:
                 iec_item = self.iec_read_values(
@@ -209,7 +209,7 @@ class EnergomeraHassMqtt:
         """
         try:
             await self.set_online_sensor(False)
-            await self._mqtt_client.disconnect()
+            await self._mqtt_client.__aexit__(None, None, None)
         except Exception:  # pylint: disable=broad-except
             pass
 

--- a/src/energomera_hass_mqtt/hass_mqtt.py
+++ b/src/energomera_hass_mqtt/hass_mqtt.py
@@ -167,8 +167,7 @@ class EnergomeraHassMqtt:
             await self.set_online_sensor(False, setup_only=True)
             # The connection to MQTT broker is instantiated only once, if not
             # connected previously.
-            # pylint:disable=unnecessary-dunder-call
-            await self._mqtt_client.__aenter__()
+            await self._mqtt_client.connect()
             # Process parameters requested
             for param in self._config.of.parameters:
                 iec_item = self.iec_read_values(
@@ -209,7 +208,7 @@ class EnergomeraHassMqtt:
         """
         try:
             await self.set_online_sensor(False)
-            await self._mqtt_client.__aexit__(None, None, None)
+            await self._mqtt_client.disconnect()
         except Exception:  # pylint: disable=broad-except
             pass
 

--- a/src/energomera_hass_mqtt/mqtt_client.py
+++ b/src/energomera_hass_mqtt/mqtt_client.py
@@ -19,23 +19,17 @@
 # SOFTWARE.
 
 """
-The package provides additional functionality over `asyncio_mqtt`.
+The package provides additional functionality over `aiomqtt`.
 """
 import logging
-import asyncio_mqtt
+import aiomqtt
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class MqttClient(asyncio_mqtt.Client):
+class MqttClient(aiomqtt.Client):
     """
-    Class attribute allowing to provide MQTT keepalive down to MQTT client.
-    Used only by tests at the moment, thus no interface controlling the
-    attribute is provided.
-    """
-    _keepalive = None
-    """
-    The class extends the `asyncio_mqtt.Client` to provide better convenience
+    The class extends the `aiomqtt.Client` to provide better convenience
     working with last wills. Namely, the original class only allows setting the
     last will thru its constructor, while the `EnergomeraHassMqtt` consuming it
     only has required property for that around actual publish calls.
@@ -45,39 +39,7 @@ class MqttClient(asyncio_mqtt.Client):
     """
     def __init__(self, *args, **kwargs):
         self._will_set = 'will' in kwargs
-        # Pass keepalive option down to parent class if set
-        if self._keepalive:
-            kwargs['keepalive'] = self._keepalive
         super().__init__(logger=_LOGGER, *args, **kwargs)
-
-    async def connect(self, *args, **kwargs):
-        """
-        Connects to MQTT broker.
-        Multiple calls will result only in single call to `connect()` method of
-        parent class if the MQTT client needs a connection (not being connected
-        or got disconnected), to allow the method to be called within a process
-        loop with no risk of constantly reinitializing MQTT broker connection.
-
-        :param args: Pass-through positional arguments for parent class
-        :param kwargs: Pass-through keyword arguments for parent class
-
-        """
-        # Using combination of `self._connected` and `self._disconnected` (both
-        # inherited from `asyncio_mqtt.client`) to detect of MQTT client needs
-        # a reconnection upon a network error isn't reliable - the former isn't
-        # finished even after a disconnect, while the latter stays with
-        # exception after a successfull reconnect. Neither
-        # `self._client.is_connected` (from Paho client) is - is returns True
-        # if socket is disconnected due to network error. Only testing for
-        # `self._client.socket()` (from Paho client as well) fits the purpose -
-        # None indicates the client needs `connect`
-        if self._client.socket():
-            _LOGGER.debug(
-                'MQTT client is already connected, skipping subsequent attempt'
-            )
-            return
-
-        await super().connect(*args, *kwargs)
 
     def will_set(self, *args, **kwargs):
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1046,7 +1046,7 @@ def mock_mqtt():
     '''
     # Mock the calls we interested in
     with patch.multiple(MqttClient,
-                        publish=DEFAULT, connect=DEFAULT,
+                        publish=DEFAULT, __aenter__=DEFAULT,
                         new_callable=AsyncMock) as mocks:
         # Python 3.7 can't properly distinguish between regular and async calls
         # using `MagicMock` or `AsyncMock` respectively, so patch the regular

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1046,7 +1046,7 @@ def mock_mqtt():
     '''
     # Mock the calls we interested in
     with patch.multiple(MqttClient,
-                        publish=DEFAULT, __aenter__=DEFAULT,
+                        publish=DEFAULT, connect=DEFAULT,
                         new_callable=AsyncMock) as mocks:
         # Python 3.7 can't properly distinguish between regular and async calls
         # using `MagicMock` or `AsyncMock` respectively, so patch the regular

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,12 +10,7 @@ from unittest.mock import patch, call, DEFAULT
 import pytest
 import iec62056_21.transports
 from energomera_hass_mqtt.mqtt_client import MqttClient
-try:
-    from unittest.mock import AsyncMock
-except ImportError:
-    # AsyncMock introduced in Python 3.8, import from alternative package if
-    # older
-    from mock import AsyncMock
+from unittest.mock import AsyncMock
 
 
 SERIAL_EXCHANGE_COMPLETE = [
@@ -1046,11 +1041,6 @@ def mock_mqtt():
     '''
     # Mock the calls we interested in
     with patch.multiple(MqttClient,
-                        publish=DEFAULT, connect=DEFAULT,
+                        publish=DEFAULT, connect=DEFAULT, will_set=DEFAULT,
                         new_callable=AsyncMock) as mocks:
-        # Python 3.7 can't properly distinguish between regular and async calls
-        # using `MagicMock` or `AsyncMock` respectively, so patch the regular
-        # method separately
-        with patch.object(MqttClient, 'will_set') as will_mock:
-            mocks.update({'will_set': will_mock})
-            yield mocks
+        yield mocks

--- a/tests/test_online_sensor.py
+++ b/tests/test_online_sensor.py
@@ -47,7 +47,7 @@ def test_online_sensor(mock_mqtt):
             mock_mqtt['will_set'].call_args_list[-1] == online_sensor_off_call
         )
         return DEFAULT
-    mock_mqtt['__aenter__'].side_effect = trace_connect
+    mock_mqtt['connect'].side_effect = trace_connect
 
     # Perform a normal run
     main()

--- a/tests/test_online_sensor.py
+++ b/tests/test_online_sensor.py
@@ -47,7 +47,7 @@ def test_online_sensor(mock_mqtt):
             mock_mqtt['will_set'].call_args_list[-1] == online_sensor_off_call
         )
         return DEFAULT
-    mock_mqtt['connect'].side_effect = trace_connect
+    mock_mqtt['__aenter__'].side_effect = trace_connect
 
     # Perform a normal run
     main()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310,311}
+envlist = py{38,39,310,311,312}
 
 # Define the minimal tox version required to run;
 # if the host tox is less than this the tool with create an environment and
@@ -15,17 +15,11 @@ isolated_build = true
 [testenv]
 deps =
     check-manifest==0.49
-    flake8==5.0.4;python_version=="3.7"
-    flake8==7.0.0;python_version>"3.7"
-    pylint==2.15.9;python_version=="3.7"
-    pylint==3.2.0;python_version>"3.7"
-    pytest==7.2.0;python_version=="3.7"
-    pytest==8.2.0;python_version>"3.7"
-    pytest-asyncio==0.20.3;python_version=="3.7"
-    pytest-asyncio==0.23.6;python_version>"3.7"
-    pytest-cov==4.0.0;python_version=="3.7"
-    pytest-cov==5.0.0;python_version>"3.7"
-    mock==4.0.3;python_version<"3.8"
+    flake8==7.0.0
+    pylint==3.2.0
+    pytest==8.2.0
+    pytest-asyncio==0.23.6
+    pytest-cov==5.0.0
     freezegun==1.5.1
 setenv =
     # Ensure the module under test will be found under `src/` directory, in

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,8 @@ deps =
     pylint==2.15.9;python_version=="3.7"
     pylint==3.2.0;python_version>"3.7"
     pytest==8.2.0
-    pytest-asyncio==0.23.6
+    pytest-asyncio==0.20.3;python_version=="3.7"
+    pytest-asyncio==0.23.6;python_version>"3.7"
     pytest-cov==5.0.0
     mock==4.0.3;python_version<"3.8"
     freezegun==1.5.1

--- a/tox.ini
+++ b/tox.ini
@@ -16,14 +16,13 @@ isolated_build = true
 deps =
     check-manifest==0.49
     flake8==5.0.4;python_version=="3.7"
-    flake8==6.0.0;python_version>"3.7"
-    pylint==2.15.9
-    pytest==7.2.0
-    pytest-asyncio==0.20.3
-    pytest-cov==4.0.0
+    flake8==7.0.0;python_version>"3.7"
+    pylint==3.2.0
+    pytest==8.2.0
+    pytest-asyncio==0.23.6
+    pytest-cov==5.0.0
     mock==4.0.3;python_version<"3.8"
-    freezegun==1.2.2
-    docker==6.1.3
+    freezegun==1.5.1
 setenv =
     # Ensure the module under test will be found under `src/` directory, in
     # case of any test command below will attempt importing it. In particular,

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,8 @@ deps =
     pytest==8.2.0
     pytest-asyncio==0.20.3;python_version=="3.7"
     pytest-asyncio==0.23.6;python_version>"3.7"
-    pytest-cov==5.0.0
+    pytest-cov==4.0.0;python_version=="3.7"
+    pytest-cov==5.0.0;python_version>"3.7"
     mock==4.0.3;python_version<"3.8"
     freezegun==1.5.1
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,8 @@ deps =
     flake8==7.0.0;python_version>"3.7"
     pylint==2.15.9;python_version=="3.7"
     pylint==3.2.0;python_version>"3.7"
-    pytest==8.2.0
+    pytest==7.2.0;python_version=="3.7"
+    pytest==8.2.0;python_version>"3.7"
     pytest-asyncio==0.20.3;python_version=="3.7"
     pytest-asyncio==0.23.6;python_version>"3.7"
     pytest-cov==4.0.0;python_version=="3.7"

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,8 @@ deps =
     check-manifest==0.49
     flake8==5.0.4;python_version=="3.7"
     flake8==7.0.0;python_version>"3.7"
-    pylint==3.2.0
+    pylint==2.15.9;python_version=="3.7"
+    pylint==3.2.0;python_version>"3.7"
     pytest==8.2.0
     pytest-asyncio==0.23.6
     pytest-cov==5.0.0


### PR DESCRIPTION
* Migrated from `asyncio-mqtt` to `aiomqtt` in a straightforward way using `__aenter__` and `__aexit__` wrapping them into `connect`/`disconnect` methods of `MqttClient` class
* Updated runtime and development packages to most recent versions
* Github: Docker images are published on each workflow run to facilitate testing, not only when release is created