### PR TITLE
feat: Support for MQTT connection properties via environment variables

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -146,6 +146,16 @@ timestamp returned for the date being 5 days ago. An use case for that might be
 intermittent connectivity to the meter where the readings aren't sent to
 collecting system on cadence thus have gaps in data points.
 
+Environment variables
+=====================
+
+Following environment variables might be provided overriding corresponding
+configuration file entries:
+
+* ``MQTT_HOST``: Host or IP address of MQTT broker
+* ``MQTT_PORT``: Same but for the port
+* ``MQTT_USER``: User name to connect to MQTT broker with
+* ``MQTT_PASSWORD``: Same but for the password
 
 ``systemd`` support
 ===================

--- a/src/energomera_hass_mqtt/hass_mqtt.py
+++ b/src/energomera_hass_mqtt/hass_mqtt.py
@@ -25,6 +25,7 @@ HomeAssistant using MQTT.
 
 import logging
 import ssl
+from os import getenv
 
 from iec62056_21.messages import CommandMessage
 from iec62056_21.client import Iec6205621Client
@@ -95,9 +96,11 @@ class EnergomeraHassMqtt:
             mqtt_tls_context = ssl.SSLContext()
 
         self._mqtt_client = MqttClient(
-            hostname=config.of.mqtt.host, port=config.of.mqtt.port,
-            username=config.of.mqtt.user,
-            password=config.of.mqtt.password, tls_context=mqtt_tls_context,
+            hostname=getenv('MQTT_HOST', config.of.mqtt.host),
+            port=getenv('MQTT_PORT', config.of.mqtt.port),
+            username=getenv('MQTT_USER', config.of.mqtt.user),
+            password=getenv('MQTT_PASSWORD', config.of.mqtt.password),
+            tls_context=mqtt_tls_context,
             # Set MQTT keepalive to interval between meter interaction cycles,
             # so that MQTT broker will consider the client disconnected upon
             # that internal if no MQTT traffic is seen from the client.


### PR DESCRIPTION
+ Added support for providing MQTT connection properies via environment variables overriding corresponding configuration file entries:

  * `MQTT_HOST`: Host or IP address of MQTT broker
  * `MQTT_PORT`: Same but for the port
  * `MQTT_USER`: User name to connect to MQTT broker with
  * `MQTT_PASSWORD`: Same but for the password