### PR TITLE
feat: Typing hints, configuration file schema with `pydantic`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -152,7 +152,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push images
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/arm/v7,linux/arm/v6,linux/arm64
@@ -160,3 +160,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
+          # Cache the buildx cache between builds using GitHub Actions cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.13.0rc1-alpine AS build
 RUN apk add -U cargo git rust \
 	&& pip install build \
 	&& apk cache clean
-ADD . /usr/src/
+COPY . /usr/src/
 WORKDIR /usr/src/
 RUN python -m build
 RUN pip install --root target/ dist/*-`cat version.txt`*.whl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.13.0rc1-alpine AS build
 # Rust and Cargo are required to build `pyndatic-core` on ARM platforms
-RUN apk add -U git rust cargo
+RUN apk add -U cargo git rust
 RUN pip install build
 ADD . src/
 WORKDIR src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM python:3.13.0rc1-alpine as build
-RUN apk add -U git
+FROM python:3.13.0rc1-alpine AS build
+# Rust and Cargo are required to build `pyndatic-core` on ARM platforms
+RUN apk add -U git rust cargo
 RUN pip install build
 ADD . src/
 WORKDIR src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,18 @@
 FROM python:3.13.0rc1-alpine AS build
 # Rust and Cargo are required to build `pyndatic-core` on ARM platforms
-RUN apk add -U cargo git rust
-RUN pip install build
-ADD . src/
-WORKDIR src
+RUN apk add -U cargo git rust \
+	&& pip install build \
+	&& apk cache clean
+ADD . /usr/src/
+WORKDIR /usr/src/
 RUN python -m build
 RUN pip install --root target/ dist/*-`cat version.txt`*.whl
 
 FROM python:3.13.0rc1-alpine
 COPY --from=build \
-	src/target/root/.local/lib/ /usr/local/lib/
+	/usr/src/target/root/.local/lib/ /usr/local/lib/
 COPY --from=build \
-	src/target/root/.local/bin/ \
+	/usr/src/target/root/.local/bin/ \
 	/usr/local/bin/
 
 ENTRYPOINT ["energomera-hass-mqtt"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,6 +24,7 @@ extensions = [
     'sphinx.ext.autosummary',
     'sphinx.ext.intersphinx',
     'sphinx.ext.autosectionlabel',
+    'sphinx_autodoc_typehints',
 ]
 
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,5 +2,5 @@ sphinx-rtd-theme
 sphinx-autodoc-typehints==2.3.0
 -r ../requirements.txt
 setuptools>=70.0.0 # not directly required, pinned by Snyk to avoid a vulnerability
-requests>=2.32.0 # not directly required, pinned by Snyk to avoid a vulnerability
+requests>=2.32.2 # not directly required, pinned by Snyk to avoid a vulnerability
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,10 +1,6 @@
 sphinx-rtd-theme
-git+https://github.com/hostcc/iec62056-21.git@feature/transport-improvements
-aiomqtt
-pyyaml
-schema
-addict
+sphinx-autodoc-typehints==2.3.0
+-r ../requirements.txt
 setuptools>=70.0.0 # not directly required, pinned by Snyk to avoid a vulnerability
-python-dateutil
 requests>=2.32.0 # not directly required, pinned by Snyk to avoid a vulnerability
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,8 @@ signature-mutators = [
 	# `patch.object` decorator of `unittest.mock`
 	"unittest.mock._patch_object"
 ]
+
+[[tool.mypy.overrides]]
+# No typing support in the module
+module = "iec62056_21.*"
+ignore_missing_imports = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+iec62056-21 @ git+https://github.com/hostcc/iec62056-21.git@feature/transport-improvements
+aiomqtt==2.1.0
+pyyaml==6.0.1
+pydantic==2.9.0
+python-dateutil==2.9.0.post0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,11 @@
+-r requirements.txt
+check-manifest==0.49
+flake8==7.0.0
+pylint==3.2.0
+pytest==8.2.0
+pytest-asyncio==0.23.6
+pytest-cov==5.0.0
+freezegun==1.5.1
+mypy==1.11.2
+types-python-dateutil==2.8.19.14
+types-PyYAML==6.0.12

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,13 +29,7 @@ package_dir =
 	= src
 packages = find:
 python_requires = >=3.8
-install_requires =
-	iec62056-21 @ git+https://github.com/hostcc/iec62056-21.git@feature/transport-improvements
-	addict==2.4.0
-	aiomqtt==2.1.0
-	pyyaml==6.0.1
-	schema==0.7.7
-	python-dateutil==2.9.0
+install_requires = file:requirements.txt
 
 [options.packages.find]
 where = src

--- a/src/energomera_hass_mqtt/__init__.py
+++ b/src/energomera_hass_mqtt/__init__.py
@@ -22,10 +22,16 @@
 Package to read data from Energomera energy meter and send over to
 HomeAssistant using MQTT.
 """
-from .const import (  # noqa: F401
-    DEFAULT_CONFIG_FILE, DEFAULT_CONFIG
+from .const import (
+    DEFAULT_CONFIG_FILE
 )
-from .config import (  # noqa: F401
-    EnergomeraConfig, EnergomeraConfigError
-)
-from .hass_mqtt import EnergomeraHassMqtt  # noqa: F401
+from .config import EnergomeraConfig
+from .exceptions import EnergomeraMeterError, EnergomeraConfigError
+from .schema import ConfigSchema
+from .hass_mqtt import EnergomeraHassMqtt
+
+__all__ = [
+    'DEFAULT_CONFIG_FILE', 'EnergomeraConfig',
+    'EnergomeraConfigError', 'EnergomeraMeterError',
+    'EnergomeraHassMqtt', 'ConfigSchema'
+]

--- a/src/energomera_hass_mqtt/config.py
+++ b/src/energomera_hass_mqtt/config.py
@@ -38,7 +38,7 @@ from .exceptions import EnergomeraConfigError
 
 class EnergomeraConfig:
     """
-    Class representing configuration for :class:`EnergomeraHassMqtt` one.
+    Class representing configuration for :class:`EnergomeraHassMqtt`.
 
     :param config_file: Name of configuration file
     :param content: Literal content representing the configuration

--- a/src/energomera_hass_mqtt/const.py
+++ b/src/energomera_hass_mqtt/const.py
@@ -21,125 +21,154 @@
 """
 Module to hold various constants
 """
-from addict import Dict
-
+import logging
 DEFAULT_CONFIG_FILE = '/etc/energomera/config.yaml'
 
-# Default parameters to use when configuration file has none
-DEFAULT_CONFIG = Dict(
-    general=dict(
-        oneshot=False,
-        intercycle_delay=30,
-        logging_level='error',
-        include_default_parameters=False,
-    ),
-    meter=dict(
-        timeout=30,
-    ),
-    mqtt=dict(
-        port=1883,
-        tls=True,
-    ),
-    parameters=[
-        dict(address='ET0PE',
-             name='Cumulative energy',
-             device_class='energy',
-             state_class='total_increasing',
-             unit='kWh',
-             response_idx=0,
-             additional_data=None,
-             entity_name=None),
-        dict(address='ECMPE',
-             name='Monthly energy',
-             device_class='energy',
-             state_class='total',
-             unit='kWh',
-             response_idx=0,
-             additional_data=None,
-             entity_name=None),
-        dict(address='ENMPE',
-             name='Cumulative energy, previous month',
-             device_class='energy',
-             state_class='total_increasing',
-             unit='kWh',
-             response_idx=0,
-             additional_data='{{ energomera_prev_month }}',
-             entity_name='ENMPE_PREV_MONTH'),
-        dict(address='EAMPE',
-             name='Previous month energy',
-             device_class='energy',
-             state_class='total',
-             unit='kWh',
-             response_idx=0,
-             additional_data='{{ energomera_prev_month }}',
-             entity_name='ECMPE_PREV_MONTH'),
-        dict(address='ECDPE',
-             name='Daily energy',
-             device_class='energy',
-             state_class='total',
-             unit='kWh',
-             response_idx=0,
-             additional_data=None,
-             entity_name=None),
-        dict(address='POWPP',
-             name=[
-                 'Active energy, phase A',
-                 'Active energy, phase B',
-                 'Active energy, phase C'
-             ],
-             device_class='power',
-             state_class='measurement',
-             unit='kW',
-             response_idx=None,
-             additional_data=None,
-             entity_name=None),
-        dict(address='POWEP',
-             name='Active energy',
-             device_class='power',
-             state_class='measurement',
-             unit='kW',
-             response_idx=None,
-             additional_data=None,
-             entity_name=None),
-        dict(address='VOLTA',
-             name=[
-                 'Voltage, phase A',
-                 'Voltage, phase B',
-                 'Voltage, phase C'
-             ],
-             device_class='voltage',
-             state_class='measurement',
-             unit='V',
-             response_idx=None,
-             additional_data=None,
-             entity_name=None),
-        dict(address='VNULL',
-             name='Neutral voltage',
-             device_class='voltage',
-             state_class='measurement',
-             unit='V',
-             response_idx=None,
-             additional_data=None,
-             entity_name=None),
-        dict(address='CURRE',
-             name=[
-                 'Current, phase A',
-                 'Current, phase B',
-                 'Current, phase C'
-             ],
-             device_class='current',
-             state_class='measurement',
-             unit='A',
-             response_idx=None,
-             additional_data=None,
-             entity_name=None),
-        dict(address='FREQU',
-             name='Frequency',
-             device_class='frequency',
-             state_class='measurement',
-             unit='Hz',
-             response_idx=None,
-             additional_data=None,
-             entity_name=None),
-    ]
+LOGGING_LEVELS = dict(
+    critical=logging.CRITICAL,
+    error=logging.ERROR,
+    warning=logging.WARNING,
+    info=logging.INFO,
+    debug=logging.DEBUG,
 )
+# Default parameters to use when configuration file has none
+DEFAULT_CONFIG_GENERAL_ONESHOT = False
+DEFAULT_CONFIG_GENERAL_INTERCYCLE_DELAY = 30
+DEFAULT_CONFIG_GENERAL_LOGGING_LEVEL = 'error'
+DEFAULT_CONFIG_GENERAL_INCLUDE_DEFAULT_PARAMETERS = False
+DEFAULT_CONFIG_GENERAL = dict(
+    oneshot=DEFAULT_CONFIG_GENERAL_ONESHOT,
+    intercycle_delay=DEFAULT_CONFIG_GENERAL_INTERCYCLE_DELAY,
+    logging_level=DEFAULT_CONFIG_GENERAL_LOGGING_LEVEL,
+    include_default_parameters=(
+        DEFAULT_CONFIG_GENERAL_INCLUDE_DEFAULT_PARAMETERS
+    )
+)
+DEFAULT_CONFIG_METER_TIMEOUT = 30
+
+DEFAULT_CONFIG_MQTT_PORT = 1883
+DEFAULT_CONFIG_MQTT_TLS = True
+
+DEFAULT_CONFIG_PARAMETERS = [
+    dict(
+        address='ET0PE',
+        name='Cumulative energy',
+        device_class='energy',
+        state_class='total_increasing',
+        unit='kWh',
+        response_idx=0,
+        additional_data=None,
+        entity_name=None
+    ),
+    dict(
+        address='ECMPE',
+        name='Monthly energy',
+        device_class='energy',
+        state_class='total',
+        unit='kWh',
+        response_idx=0,
+        additional_data=None,
+        entity_name=None),
+    dict(
+        address='ENMPE',
+        name='Cumulative energy, previous month',
+        device_class='energy',
+        state_class='total_increasing',
+        unit='kWh',
+        response_idx=0,
+        additional_data='{{ energomera_prev_month }}',
+        entity_name='ENMPE_PREV_MONTH'
+    ),
+    dict(
+        address='EAMPE',
+        name='Previous month energy',
+        device_class='energy',
+        state_class='total',
+        unit='kWh',
+        response_idx=0,
+        additional_data='{{ energomera_prev_month }}',
+        entity_name='ECMPE_PREV_MONTH'
+    ),
+    dict(
+        address='ECDPE',
+        name='Daily energy',
+        device_class='energy',
+        state_class='total',
+        unit='kWh',
+        response_idx=0,
+        additional_data=None,
+        entity_name=None
+    ),
+    dict(
+        address='POWPP',
+        name=[
+            'Active energy, phase A',
+            'Active energy, phase B',
+            'Active energy, phase C'
+        ],
+        device_class='power',
+        state_class='measurement',
+        unit='kW',
+        response_idx=None,
+        additional_data=None,
+        entity_name=None
+    ),
+    dict(
+        address='POWEP',
+        name='Active energy',
+        device_class='power',
+        state_class='measurement',
+        unit='kW',
+        response_idx=None,
+        additional_data=None,
+        entity_name=None
+    ),
+    dict(
+        address='VOLTA',
+        name=[
+            'Voltage, phase A',
+            'Voltage, phase B',
+            'Voltage, phase C'
+        ],
+        device_class='voltage',
+        state_class='measurement',
+        unit='V',
+        response_idx=None,
+        additional_data=None,
+        entity_name=None
+    ),
+    dict(
+        address='VNULL',
+        name='Neutral voltage',
+        device_class='voltage',
+        state_class='measurement',
+        unit='V',
+        response_idx=None,
+        additional_data=None,
+        entity_name=None
+    ),
+    dict(
+        address='CURRE',
+        name=[
+            'Current, phase A',
+            'Current, phase B',
+            'Current, phase C'
+        ],
+        device_class='current',
+        state_class='measurement',
+        unit='A',
+        response_idx=None,
+        additional_data=None,
+        entity_name=None
+    ),
+    dict(
+        address='FREQU',
+        name='Frequency',
+        device_class='frequency',
+        state_class='measurement',
+        unit='Hz',
+        response_idx=None,
+        additional_data=None,
+        entity_name=None
+    ),
+]

--- a/src/energomera_hass_mqtt/exceptions.py
+++ b/src/energomera_hass_mqtt/exceptions.py
@@ -1,0 +1,15 @@
+"""
+Exceptions for the package.
+"""
+
+
+class EnergomeraConfigError(Exception):
+    """
+    Exception thrown when configuration processing encounters an error.
+    """
+
+
+class EnergomeraMeterError(Exception):
+    """
+    Exception thrown when the energy meter communication fails.
+    """

--- a/src/energomera_hass_mqtt/exceptions.py
+++ b/src/energomera_hass_mqtt/exceptions.py
@@ -1,3 +1,23 @@
+# Copyright (c) 2024 Ilia Sotnikov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 """
 Exceptions for the package.
 """

--- a/src/energomera_hass_mqtt/extra_sensors.py
+++ b/src/energomera_hass_mqtt/extra_sensors.py
@@ -23,10 +23,7 @@ Package to provide additional sensors on top of `IecToHassSensor`.
 """
 from __future__ import annotations
 from typing import Dict, Union, Any
-import logging
 from .iec_hass_sensor import IecToHassSensor
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class IecToHassBinarySensor(IecToHassSensor):

--- a/src/energomera_hass_mqtt/extra_sensors.py
+++ b/src/energomera_hass_mqtt/extra_sensors.py
@@ -21,7 +21,8 @@
 """
 Package to provide additional sensors on top of `IecToHassSensor`.
 """
-
+from __future__ import annotations
+from typing import Dict, Union, Any
 import logging
 from .iec_hass_sensor import IecToHassSensor
 
@@ -34,33 +35,14 @@ class IecToHassBinarySensor(IecToHassSensor):
     """
     _mqtt_topic_base = 'binary_sensor'
 
-    def hass_config_payload(self):
-        """
-        Provides payload for HASS MQTT discovery relevant to binary sensor.
-        """
-        # Code duplicates `IecToHassSensor` will be fixed separately
-        # pylint:disable=duplicate-code
-        return dict(
-            name=self._hass_item_name,
-            device=dict(
-                name=self._serial_number,
-                ids=self._hass_device_id,
-                model=self._model,
-                sw_version=self._sw_version,
-            ),
-            device_class=self._config_param.device_class,
-            unique_id=self._hass_unique_id,
-            object_id=self._hass_unique_id,
-            state_topic=self._hass_state_topic,
-            value_template='{{ value_json.value }}',
-        )
-
-    def hass_state_payload(self, value):  # pylint: disable=no-self-use
+    def hass_state_payload(
+        self, value: Union[str, str]
+    ) -> Dict[str, str]:  # pylint: disable=no-self-use
         """
         Transforms the binary sensor payload to the format understood by HASS
         MQTT discovery for the sensor type.
 
-        :param str,bool value: The sensor value
+        :param value: The sensor value
         """
         if isinstance(value, bool):
             b_value = value
@@ -80,11 +62,11 @@ class PseudoBinarySensor(IecToHassBinarySensor):
     """
     Represents a pseudo-sensor, i.e. one doesn't exist on meter.
 
-    :param str,bool value: The sensor value
+    :param value: The sensor value
     :param args: Parameters passed through to parent constructor
     :param kwargs: Keyword parameters passed through to parent constructor
     """
-    def __init__(self, value, *args, **kwargs):
+    def __init__(self, value: bool, *args: Any, **kwargs: Any):
         class PseudoValue:  # pylint: disable=too-few-public-methods
             """
             Mimics `class`:iec62056_21.messages.AnswerDataMessage to store the
@@ -94,9 +76,10 @@ class PseudoBinarySensor(IecToHassBinarySensor):
             """
             value = None
 
-            def __init__(self, value):
+            def __init__(self, value: bool) -> None:
                 self.value = value
 
         # Invoke the parent constructor providing `iec_item` from the
         # pseudo-sensor value
-        super().__init__(iec_item=[PseudoValue(value)], *args, **kwargs)
+        kwargs['iec_item'] = [PseudoValue(value)]
+        super().__init__(*args, **kwargs)

--- a/src/energomera_hass_mqtt/mqtt_client.py
+++ b/src/energomera_hass_mqtt/mqtt_client.py
@@ -21,6 +21,8 @@
 """
 The package provides additional functionality over `aiomqtt`.
 """
+from __future__ import annotations
+from typing import Any, Literal
 import logging
 import asyncio
 import aiomqtt
@@ -33,18 +35,19 @@ class DummyLock(asyncio.Lock):
     Class providing dummy functionality of `asyncio.Lock` - that is, no locking
     is actually done and it reports being always unlocked.
     '''
-    def locked(self):
+    def locked(self) -> bool:
         '''
         Provides status of the lock being always unlocked.
         '''
         return False
 
-    async def acquire(self):
+    async def acquire(self) -> Literal[True]:
         '''
         Does nothing.
         '''
+        return True
 
-    def release(self):
+    def release(self) -> None:
         '''
         Does nothing.
         '''
@@ -60,14 +63,14 @@ class MqttClient(aiomqtt.Client):
     :param args: Pass-through positional arguments for parent class
     :param kwargs: Pass-through keyword arguments for parent class
     """
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         self._will_set = 'will' in kwargs
         super().__init__(logger=_LOGGER, *args, **kwargs)
         # Skip locking in `__aenter__` and `__aexit__` - those aren't used with
         # context manager, rather as regular methods, especially the former
         self._lock = DummyLock()
 
-    async def connect(self):
+    async def connect(self) -> None:
         """
         Connects to MQTT broker using `__aenter__` method of the base class as
         recommended in
@@ -96,7 +99,7 @@ class MqttClient(aiomqtt.Client):
         # pylint:disable=unnecessary-dunder-call
         await self.__aenter__()
 
-    async def disconnect(self):
+    async def disconnect(self) -> None:
         """
         Disconnects from MQTT broker using `__aexit__` method of the base class
         as per migration guide above.
@@ -104,7 +107,7 @@ class MqttClient(aiomqtt.Client):
         # pylint:disable=unnecessary-dunder-call
         await self.__aexit__(None, None, None)
 
-    def will_set(self, *args, **kwargs):
+    def will_set(self, *args: Any, **kwargs: Any) -> None:
         """
         Allows setting last will to the underlying MQTT client.
 
@@ -119,7 +122,7 @@ class MqttClient(aiomqtt.Client):
         self._client.will_set(*args, **kwargs)
         self._will_set = True
 
-    def will_clear(self):
+    def will_clear(self) -> None:
         """
         Clears the last will might have been set previously.
         """

--- a/src/energomera_hass_mqtt/schema.py
+++ b/src/energomera_hass_mqtt/schema.py
@@ -1,0 +1,105 @@
+"""
+Module containing configuration file schema.
+"""
+from __future__ import annotations
+from typing import Optional, List, Union
+from pydantic import (
+    BaseModel, field_validator, SecretStr, model_validator
+)
+from .const import (
+    DEFAULT_CONFIG_GENERAL_INCLUDE_DEFAULT_PARAMETERS,
+    DEFAULT_CONFIG_GENERAL_INTERCYCLE_DELAY,
+    DEFAULT_CONFIG_GENERAL_LOGGING_LEVEL, DEFAULT_CONFIG_GENERAL_ONESHOT,
+    DEFAULT_CONFIG_METER_TIMEOUT, DEFAULT_CONFIG_MQTT_PORT,
+    DEFAULT_CONFIG_GENERAL, LOGGING_LEVELS
+)
+
+
+class ConfigGeneralSchema(BaseModel):
+    """
+    Class representing configuration schema for general settings.
+    """
+    oneshot: bool = DEFAULT_CONFIG_GENERAL_ONESHOT
+    intercycle_delay: int = DEFAULT_CONFIG_GENERAL_INTERCYCLE_DELAY
+    logging_level: str = DEFAULT_CONFIG_GENERAL_LOGGING_LEVEL
+    include_default_parameters: bool = (
+        DEFAULT_CONFIG_GENERAL_INCLUDE_DEFAULT_PARAMETERS
+    )
+
+    @field_validator('logging_level', mode='after')
+    @classmethod
+    def validate_logging_level(cls, value: str) -> str:
+        """
+        Validates logging level.
+        """
+        valid_levels = LOGGING_LEVELS.keys()
+        if value not in valid_levels:
+            valid_levels_str = ', '.join([f"'{x}'" for x in valid_levels])
+            raise ValueError(
+                f'should be one of {valid_levels_str}'
+            )
+
+        return value
+
+
+class ConfigMeterSchema(BaseModel):
+    """
+    Class representing configuration schema for meter connection.
+    """
+    port: str
+    password: SecretStr
+    timeout: int = DEFAULT_CONFIG_METER_TIMEOUT
+
+
+class ConfigMqttSchema(BaseModel):
+    """
+    Class representing configuration schema for MQTT connection.
+    """
+    host: str
+    port: int = DEFAULT_CONFIG_MQTT_PORT
+    user: Optional[str] = None
+    password: Optional[SecretStr] = None
+    hass_discovery_prefix: str = 'homeassistant'
+    tls: bool = True
+
+
+class ConfigParameterSchema(BaseModel):
+    """
+    Class representing configuration schema for a single parameter.
+    """
+    address: str
+    name: Union[str, List[str]]
+    device_class: str
+    state_class: Optional[str] = None
+    unit: Optional[str] = None
+    additional_data: Optional[str] = None
+    entity_name: Optional[str] = None
+    response_idx: Optional[int] = None
+
+
+class ConfigSchema(BaseModel):
+    """
+    Class representing configuration schema.
+    """
+    general: ConfigGeneralSchema = (
+        ConfigGeneralSchema.model_validate(DEFAULT_CONFIG_GENERAL)
+    )
+    meter: ConfigMeterSchema
+    mqtt: ConfigMqttSchema
+    parameters: List[ConfigParameterSchema] = []
+
+    @model_validator(mode='after')
+    def validate_parameters(self: ConfigSchema) -> ConfigSchema:
+        """
+        Validates parameters.
+        """
+        if (
+            not self.parameters
+            and not self.general.include_default_parameters
+        ):
+            raise ValueError(
+                "'parameters' should not be empty if"
+                " 'general.include_default_parameters' is not enabled"
+            )
+
+        return self

--- a/src/energomera_hass_mqtt/schema.py
+++ b/src/energomera_hass_mqtt/schema.py
@@ -1,3 +1,23 @@
+# Copyright (c) 2024 Ilia Sotnikov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 """
 Module containing configuration file schema.
 """
@@ -81,6 +101,8 @@ class ConfigSchema(BaseModel):
     """
     Class representing configuration schema.
     """
+    # Whole `general` section could be skipped, as it is provided with the
+    # defaults below
     general: ConfigGeneralSchema = (
         ConfigGeneralSchema.model_validate(DEFAULT_CONFIG_GENERAL)
     )
@@ -91,7 +113,7 @@ class ConfigSchema(BaseModel):
     @model_validator(mode='after')
     def validate_parameters(self: ConfigSchema) -> ConfigSchema:
         """
-        Validates parameters.
+        Validates `parameters` section.
         """
         if (
             not self.parameters

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,23 @@
+# Copyright (c) 2022 Ilia Sotnikov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 '''
 Shared data structures and fixtures.
 '''

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,18 +2,21 @@
 Shared data structures and fixtures.
 '''
 # pylint: disable=too-many-lines
-
+from __future__ import annotations
+from typing import Dict, Iterator, Union, List
 import json
 import sys
 from functools import reduce
-from unittest.mock import patch, call, DEFAULT
+from unittest.mock import patch, call, DEFAULT, AsyncMock, Mock
 import pytest
+from pytest import FixtureRequest
 import iec62056_21.transports
 from energomera_hass_mqtt.mqtt_client import MqttClient
-from unittest.mock import AsyncMock
 
+MockMqttT = Dict[str, Mock]
+MockSerialT = Dict[str, Mock]
 
-SERIAL_EXCHANGE_COMPLETE = [
+SERIAL_EXCHANGE_BASE = [
     {
         'receive_bytes': b'/?!\r\n',
         'send_bytes': b'/EKT5CE301v12\r\n',
@@ -30,6 +33,9 @@ SERIAL_EXCHANGE_COMPLETE = [
         'receive_bytes': b'\x01R1\x02HELLO()\x03M',
         'send_bytes': b'\x02HELLO(2,CE301,12,00123456,dummy)\r\n\x03\x01',
     },
+]
+
+SERIAL_EXCHANGE_COMPLETE = SERIAL_EXCHANGE_BASE + [
     {
         'receive_bytes': b'\x01R1\x02ET0PE()\x037',
         'send_bytes':
@@ -856,7 +862,7 @@ MQTT_PUBLISH_CALLS_COMPLETE = [
     ),
 ]
 
-CONFIG_YAML = '''
+CONFIG_YAML_BASE = '''
     general:
         oneshot: true
     meter:
@@ -871,6 +877,8 @@ CONFIG_YAML = '''
       password: mqtt_dummy_password
       # Leveraged by Docker-based tests since the broker is TLS-unaware
       tls: false
+'''
+CONFIG_YAML = CONFIG_YAML_BASE + '''
     parameters:
         - address: ET0PE
           device_class: energy
@@ -968,7 +976,7 @@ CONFIG_YAML = '''
 
 
 @pytest.fixture
-def mock_config(request):
+def mock_config(request: FixtureRequest) -> Iterator[None]:
     '''
     Provides mocked configuration file, to be used as context manager.
     '''
@@ -987,7 +995,9 @@ def mock_config(request):
 
 
 @pytest.fixture
-def mock_serial(request):
+def mock_serial(
+    request: FixtureRequest
+) -> Iterator[MockSerialT]:
     '''
     Provides necessary serial mocks, to be used as context manager.
     '''
@@ -1009,7 +1019,7 @@ def mock_serial(request):
         with patch.multiple(iec62056_21.transports.SerialTransport,
                             _send=DEFAULT, _recv=DEFAULT) as mocks:
             # Simulate data received from serial port.
-            mocked_serial_exchange = [
+            mocked_serial_exchange: List[Union[bytes, type[TimeoutError]]] = [
                 # Accessing `bytes` by subscription or via iterator (what
                 # `side_effect` internally does for iterable) will result in
                 # integer, so to retain the type the nested arrays each
@@ -1035,7 +1045,7 @@ def mock_serial(request):
 
 
 @pytest.fixture
-def mock_mqtt():
+def mock_mqtt() -> Iterator[MockMqttT]:
     '''
     Provides necessary MQTT mocks, to be used as context manager.
     '''

--- a/tests/test_config_payload_update.py
+++ b/tests/test_config_payload_update.py
@@ -1,3 +1,23 @@
+# Copyright (c) 2023 Ilia Sotnikov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 '''
 Tests for handling HomeAssistant configuration payloads.
 '''

--- a/tests/test_config_payload_update.py
+++ b/tests/test_config_payload_update.py
@@ -4,60 +4,35 @@ Tests for handling HomeAssistant configuration payloads.
 import json
 from unittest.mock import call
 import pytest
+from conftest import (
+    CONFIG_YAML_BASE, MockMqttT, MockSerialT, SERIAL_EXCHANGE_BASE
+)
 from energomera_hass_mqtt.main import main
 
-serial_exchange = [
-    {
-        'receive_bytes': b'/?!\r\n',
-        'send_bytes': b'/EKT5CE301v12\r\n',
-    },
-    {
-        'receive_bytes': b'\x06051\r\n',
-        'send_bytes': b'\x01P0\x02(777777)\x03\x20',
-    },
-    {
-        'receive_bytes': b'\x01P1\x02(dummy)\x03\x03',
-        'send_bytes': b'\x06',
-    },
-    {
-        'receive_bytes': b'\x01R1\x02HELLO()\x03M',
-        'send_bytes': b'\x02HELLO(2,CE301,12,00123456,dummy)\r\n\x03\x01',
-    },
+serial_exchange = SERIAL_EXCHANGE_BASE + [
     {
         'receive_bytes': b'\x01R1\x02ET0PE()\x037',
         'send_bytes':
-            b'\x02ET0PE(16907.9477764)\r\n'
-            b'ET0PE(11504.3875082)\r\n'
-            b'ET0PE(3628.2698795)\r\n'
-            b'ET0PE(1775.2903887)\r\n'
+            b'\x02ET0PE(0.0)\r\n'
+            b'ET0PE(0.0)\r\n'
+            b'ET0PE(0.0)\r\n'
+            b'ET0PE(0.0)\r\n'
             b'ET0PE(0.0)\r\n'
             b'ET0PE(0.0)\r\n\x03\x04',
     },
     {
         'receive_bytes': b'\x01R1\x02ET0PE()\x037',
         'send_bytes':
-            b'\x02ET0PE(16907.9477764)\r\n'
-            b'ET0PE(11504.3875082)\r\n'
-            b'ET0PE(3628.2698795)\r\n'
-            b'ET0PE(1775.2903887)\r\n'
+            b'\x02ET0PE(0.0)\r\n'
+            b'ET0PE(0.0)\r\n'
+            b'ET0PE(0.0)\r\n'
+            b'ET0PE(0.0)\r\n'
             b'ET0PE(0.0)\r\n'
             b'ET0PE(0.0)\r\n\x03\x04',
     },
 ]
 
-CONFIG_YAML = '''
-    general:
-        oneshot: true
-    meter:
-      port: dummy_serial
-      password: dummy
-      timeout: 1
-    mqtt:
-      # This is important as Docker-backed tests spawn the broker exposed
-      # on the localhost
-      host: 127.0.0.1
-      user: mqtt_dummy_user
-      password: mqtt_dummy_password
+CONFIG_YAML = CONFIG_YAML_BASE + '''
     parameters:
         - address: ET0PE
           device_class: energy
@@ -75,9 +50,10 @@ CONFIG_YAML = '''
 
 
 @pytest.mark.usefixtures('mock_config')
-@pytest.mark.serial_exchange(serial_exchange)
 @pytest.mark.config_yaml(CONFIG_YAML)
-def test_config_payload_update(mock_serial, mock_mqtt):
+def test_config_payload_update(
+    mock_serial: MockSerialT, mock_mqtt: MockMqttT
+) -> None:
     '''
     Tests for configuration payload to be sent again once it changes (e.g.
     through interpolation).

--- a/tests/test_energomera.py
+++ b/tests/test_energomera.py
@@ -23,12 +23,15 @@ Tests for 'energomera_hass_mqtt' package
 '''
 from unittest.mock import call
 import pytest
-from conftest import MQTT_PUBLISH_CALLS_COMPLETE, SERIAL_EXCHANGE_COMPLETE
+from conftest import (
+    MQTT_PUBLISH_CALLS_COMPLETE, SERIAL_EXCHANGE_COMPLETE, MockMqttT,
+    MockSerialT
+)
 from energomera_hass_mqtt.main import main
 
 
 @pytest.mark.usefixtures('mock_config')
-def test_normal_run(mock_serial, mock_mqtt):
+def test_normal_run(mock_serial: MockSerialT, mock_mqtt: MockMqttT) -> None:
     '''
     Tests for normal program execution validating serial and MQTT exchanges.
     '''
@@ -41,7 +44,7 @@ def test_normal_run(mock_serial, mock_mqtt):
 
 @pytest.mark.usefixtures('mock_serial', 'mock_config', 'mock_mqtt')
 @pytest.mark.serial_simulate_timeout(True)
-def test_timeout():
+def test_timeout() -> None:
     '''
     Tests for timeout handling, no unhandled exceptions should be raised.
     '''

--- a/tests/test_online_sensor.py
+++ b/tests/test_online_sensor.py
@@ -21,14 +21,17 @@
 '''
 Tests for online sensor behavior
 '''
+from __future__ import annotations
+from typing import Any
 import json
 from unittest.mock import call, DEFAULT
 import pytest
+from conftest import MockMqttT
 from energomera_hass_mqtt.main import main
 
 
 @pytest.mark.usefixtures('mock_config', 'mock_serial')
-def test_online_sensor(mock_mqtt):
+def test_online_sensor(mock_mqtt: MockMqttT) -> None:
     '''
     Tests for handling online pseudo sensor.
     '''
@@ -42,7 +45,8 @@ def test_online_sensor(mock_mqtt):
     # 'OFF' value _before_ `MqttClient.connect()` as required by the
     # `paho-mqtt` client,
     # https://github.com/eclipse/paho.mqtt.python/blob/v1.6.0/src/paho/mqtt/client.py#L1647
-    async def trace_connect(*_, **__):
+    # `DEFAULT` is of type `Any` so the return value
+    async def trace_connect(*_: Any, **__: Any) -> Any:
         assert (
             mock_mqtt['will_set'].call_args_list[-1] == online_sensor_off_call
         )

--- a/tox.ini
+++ b/tox.ini
@@ -14,13 +14,7 @@ isolated_build = true
 
 [testenv]
 deps =
-    check-manifest==0.49
-    flake8==7.0.0
-    pylint==3.2.0
-    pytest==8.2.0
-    pytest-asyncio==0.23.6
-    pytest-cov==5.0.0
-    freezegun==1.5.1
+    -r requirements_dev.txt
 setenv =
     # Ensure the module under test will be found under `src/` directory, in
     # case of any test command below will attempt importing it. In particular,
@@ -33,19 +27,17 @@ passenv =
     RUNNER_*
     GITHUB_*
     DOCKER_*
-allowlist_externals =
-    cat
 commands =
-    check-manifest --ignore 'tox.ini,tests/**,docs/**,.pylintrc,.readthedocs.yaml,sonar-project.properties,systemd/**',Dockerfile
-    flake8 --tee --output-file=flake8.txt .
-    pylint --output-format=parseable --output=pylint.txt src/energomera_hass_mqtt
+    check-manifest --ignore 'tox.ini,tests/**,docs/**,.pylintrc,.readthedocs.yaml,sonar-project.properties,systemd/**',Dockerfile,requirements_dev.txt
+    flake8 --tee --output-file=flake8.txt src/energomera_hass_mqtt tests/
+    pylint --output-format=parseable:pylint.txt,text src/energomera_hass_mqtt tests/
+    mypy --strict src/energomera_hass_mqtt tests/
     # Ensure only traces for in-repository module is processed, not for one
     # installed by `tox` (see above for more details)
     pytest --cov=src/energomera_hass_mqtt --cov-append -v --cov-report=term-missing -s tests []
-commands_post =
-    # Show the `pylint` report to the standard output, to ease fixing the issues reported
-    cat pylint.txt
 
 [flake8]
 exclude = .tox,*.egg,build,data,scripts,docs
 select = E,W,F
+# Disable line break before operator warning, as it conflicts with W504 one
+extend-ignore = W503


### PR DESCRIPTION
* Added typing hints
* Configuration file schema now uses `pydantic` instead of `schema`/`addict` - the former provides better typing support and more comprehensive schema definitions and validation
* Requirements, both runtime and development, have been extracted into dedicated files (`requirements.txt` and `requirements_dev.txt`, respectively), so that other tools could be used to instantiate the environment
* Added startup message listing the configuration parameters
* `sphinx`: added support for automatic typing hints
* `Dockerfile`: Rust and Cargo are required to build `pyndatic-core` on  ARM platforms, they have been added to `build` stage