### PR TITLE
feat: Pseudo-sensor reflecting the duration of the meter cycle

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -124,6 +124,8 @@ Configuration file is in YAML format and supports following elements:
               # (number) - optional: Zero-based index to pick an entry from
               #  multi-value response to meter's parameter
               response_idx:
+              # (string) - optional: Category of the HASS sensor entity
+              entity_category:
 
 
 Interpolation expressions
@@ -167,7 +169,7 @@ directory.
 Docker support
 ==============
 
-There are Docker images available if you would like to run it as Docker container - you could use 
+There are Docker images available if you would like to run it as Docker container - you could use
 ``ghcr.io/hostcc/energomera-hass-mqtt:latest`` or
 ``ghcr.io/hostcc/energomera-hass-mqtt:<release version>``.
 
@@ -187,7 +189,7 @@ Then, assuming the directory is called ``config`` and resides relative to
 current directory, and the serial port the meter is connected to is
 ``/dev/ttyUSB0`` the following command will run it
 
-.. code:: 
+.. code::
 
   $ docker run --device /dev/ttyUSB0 -v `pwd`/config:/etc/energomera/ \
     ghcr.io/hostcc/energomera-hass-mqtt:latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,3 +36,8 @@ signature-mutators = [
 # No typing support in the module
 module = "iec62056_21.*"
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+# No typing support in the module
+module = "callee.*"
+ignore_missing_imports = true

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,3 +9,4 @@ freezegun==1.5.1
 mypy==1.11.2
 types-python-dateutil==2.8.19.14
 types-PyYAML==6.0.12
+callee==0.3.1

--- a/src/energomera_hass_mqtt/hass_mqtt.py
+++ b/src/energomera_hass_mqtt/hass_mqtt.py
@@ -294,7 +294,7 @@ class EnergomeraHassMqtt:
         param = ConfigParameterSchema(
             address='CYCLE_DURATION',
             name='Meter cycle duration',
-            unit='ms',
+            unit='s',
             entity_category='diagnostic',
         )
         hass_item = PseudoSensor[float](

--- a/src/energomera_hass_mqtt/hass_mqtt.py
+++ b/src/energomera_hass_mqtt/hass_mqtt.py
@@ -229,7 +229,6 @@ class EnergomeraHassMqtt:
         else:
             await self.set_online_sensor(True)
             duration = time() - start
-            _LOGGER.debug('Cycle duration: %s ms', duration)
             await self.set_duration_sensor(duration)
         finally:
             # Disconnect serial client ignoring possible
@@ -290,6 +289,7 @@ class EnergomeraHassMqtt:
         Adds a pseudo-sensor to HASS reflecting the duration of the meter
         cycle.
         """
+        _LOGGER.debug('Cycle duration: %s s', value)
         # Add a pseudo-sensor
         param = ConfigParameterSchema(
             address='CYCLE_DURATION',

--- a/src/energomera_hass_mqtt/iec_hass_sensor.py
+++ b/src/energomera_hass_mqtt/iec_hass_sensor.py
@@ -75,16 +75,15 @@ class IecToHassSensor:  # pylint: disable=too-many-instance-attributes
         self._model = model
         self._sw_version = sw_version
         self._serial_number = serial_number
-        self._state_last_will_payload: Optional[bool] = None
 
-    def set_state_last_will_payload(self, value: bool) -> None:
+    @property
+    def state_last_will_payload(self) -> Optional[str]:
         """
-        Stores there value of the last will payload for the item, i.e. sent by
-        the MQTT broker if the client disconnects uncleanly.
+        Stores value of last will payload to be set for MQTT client.
 
-        :param value: Value for last will payload
+        Should be implemented by subclasses.
         """
-        self._state_last_will_payload = value
+        return None
 
     @property
     def iec_item(self) -> List[IecDataSet]:
@@ -245,9 +244,9 @@ class IecToHassSensor:  # pylint: disable=too-many-instance-attributes
                               " at '%s' address",
                               self._hass_item_name, self._config_param.address)
                 # Set last will for MQTT if specified for the item
-                if self._state_last_will_payload is not None:
+                if self.state_last_will_payload is not None:
                     will_payload = self.hass_state_payload(
-                        value=str(self._state_last_will_payload)
+                        value=self.state_last_will_payload
                     )
                     json_will_payload = json.dumps(will_payload)
 

--- a/src/energomera_hass_mqtt/iec_hass_sensor.py
+++ b/src/energomera_hass_mqtt/iec_hass_sensor.py
@@ -201,6 +201,7 @@ class IecToHassSensor:  # pylint: disable=too-many-instance-attributes
             unit_of_measurement=self._config_param.unit,
             state_class=self._config_param.state_class,
             state_topic=self._hass_state_topic,
+            entity_category=self._config_param.entity_category,
             value_template='{{ value_json.value }}',
         )
         # Skip empty values

--- a/src/energomera_hass_mqtt/schema.py
+++ b/src/energomera_hass_mqtt/schema.py
@@ -89,12 +89,13 @@ class ConfigParameterSchema(BaseModel):
     """
     address: str
     name: Union[str, List[str]]
-    device_class: str
+    device_class: Optional[str] = None
     state_class: Optional[str] = None
     unit: Optional[str] = None
     additional_data: Optional[str] = None
     entity_name: Optional[str] = None
     response_idx: Optional[int] = None
+    entity_category: Optional[str] = None
 
 
 class ConfigSchema(BaseModel):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -891,9 +891,10 @@ MQTT_PUBLISH_CALLS_COMPLETE = [
                 },
                 'unique_id': 'CE301_00123456_CYCLE_DURATION',
                 'object_id': 'CE301_00123456_CYCLE_DURATION',
-                'unit_of_measurement': 'ms',
+                'unit_of_measurement': 's',
                 'state_topic': 'homeassistant/sensor/CE301_00123456/'
                                'CE301_00123456_CYCLE_DURATION/state',
+                'entity_category': 'diagnostic',
                 'value_template': '{{ value_json.value }}'
             }
         ),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,7 @@ import json
 import sys
 from functools import reduce
 from unittest.mock import patch, call, DEFAULT, AsyncMock, Mock
+from callee import Regex as CallRegexMatcher
 import pytest
 from pytest import FixtureRequest
 import iec62056_21.transports
@@ -35,6 +36,15 @@ from energomera_hass_mqtt.mqtt_client import MqttClient
 
 MockMqttT = Dict[str, Mock]
 MockSerialT = Dict[str, Mock]
+
+
+def re_match(pattern: str) -> str:
+    '''
+    Helper function to match regular expressions in mock calls.
+    '''
+    print(f'called: {str}')
+    return pattern
+
 
 SERIAL_EXCHANGE_BASE = [
     {
@@ -874,6 +884,33 @@ MQTT_PUBLISH_CALLS_COMPLETE = [
         topic='homeassistant/binary_sensor/CE301_00123456'
         '/CE301_00123456_IS_ONLINE/state',
         payload=json.dumps({'value': 'ON'}),
+    ),
+    call(
+        topic='homeassistant/sensor/CE301_00123456/'
+        'CE301_00123456_CYCLE_DURATION/config',
+        payload=json.dumps(
+            {
+                'name': 'Meter cycle duration',
+                'device': {
+                    'name': '00123456',
+                    'ids': 'CE301_00123456',
+                    'model': 'CE301',
+                    'sw_version': '12'
+                },
+                'unique_id': 'CE301_00123456_CYCLE_DURATION',
+                'object_id': 'CE301_00123456_CYCLE_DURATION',
+                'unit_of_measurement': 'ms',
+                'state_topic': 'homeassistant/sensor/CE301_00123456/'
+                               'CE301_00123456_CYCLE_DURATION/state',
+                'value_template': '{{ value_json.value }}'
+            }
+        ),
+        retain=True
+    ),
+    call(
+        topic='homeassistant/sensor/CE301_00123456/'
+        'CE301_00123456_CYCLE_DURATION/state',
+        payload=CallRegexMatcher('{"value": "[0-9.]+"}'),
     ),
     call(
         topic='homeassistant/binary_sensor/CE301_00123456'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,14 +38,6 @@ MockMqttT = Dict[str, Mock]
 MockSerialT = Dict[str, Mock]
 
 
-def re_match(pattern: str) -> str:
-    '''
-    Helper function to match regular expressions in mock calls.
-    '''
-    print(f'called: {str}')
-    return pattern
-
-
 SERIAL_EXCHANGE_BASE = [
     {
         'receive_bytes': b'/?!\r\n',


### PR DESCRIPTION
* Added `CYCLE_DURATION` pseudo-sensor (under `diagnostic` category) that reflects the duration in milliseconds of the meter cycle - that is, how long it took to process all parameters configured
* Added `entity_category` field to items under `parameters` section of the configuration file