### PR TITLE
fix: Attempt to fix the build cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add -U cargo git rust \
 	&& pip install build \
 	&& apk cache clean
 # Install dependencies in a separate layer to cache them
-RUN pip install -r requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip pip install -r requirements.txt
 # Build the package
 RUN python -m build \
 	&& pip install --root target/ dist/*-`cat version.txt`*.whl


### PR DESCRIPTION
* `Dockerfile` has been modified to install dependencies in a separate layer, in an attempt to make them cacheable - `pydantic-core` is a large dependency that takes a long time to build (if wheels aren't available, which is the case for ARM platforms)