### PR TITLE
feat: Added support for dry-run mode and overrides for debug/oneshot from command line

### DIFF
--- a/src/energomera_hass_mqtt/hass_mqtt.py
+++ b/src/energomera_hass_mqtt/hass_mqtt.py
@@ -74,9 +74,10 @@ class EnergomeraHassMqtt:
         return bcc.to_bytes(length=1, byteorder='big')
 
     def __init__(
-        self, config: EnergomeraConfig,
+        self, config: EnergomeraConfig, dry_run: bool = False
     ):
         self._config = config
+        self._dry_run = dry_run
         # Override the method in the `iec62056_21` library with the specific
         # implementation
         # pylint: disable=protected-access
@@ -100,6 +101,7 @@ class EnergomeraHassMqtt:
             mqtt_tls_context = ssl.SSLContext()
 
         self._mqtt_client = MqttClient(
+            dry_run=self._dry_run,
             hostname=getenv('MQTT_HOST', config.of.mqtt.host),
             port=getenv('MQTT_PORT', config.of.mqtt.port),
             username=getenv('MQTT_USER', config.of.mqtt.user),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,7 @@ import json
 import sys
 from functools import reduce
 from unittest.mock import patch, call, DEFAULT, AsyncMock, Mock
+import aiomqtt
 from callee import Regex as CallRegexMatcher
 import pytest
 from pytest import FixtureRequest
@@ -1103,4 +1104,20 @@ def mock_mqtt() -> Iterator[MockMqttT]:
     with patch.multiple(MqttClient,
                         publish=DEFAULT, connect=DEFAULT, will_set=DEFAULT,
                         new_callable=AsyncMock) as mocks:
+        yield mocks
+
+
+@pytest.fixture
+def mock_mqtt_underlying() -> Iterator[MockMqttT]:
+    '''
+    Provides necessary mocks to underlying MQTT client, to be used as context
+    manager.
+    '''
+    with patch.multiple(
+        aiomqtt.Client,
+        publish=DEFAULT,
+        __aenter__=DEFAULT,
+        __aexit__=DEFAULT,
+        new_callable=AsyncMock
+    ) as mocks:
         yield mocks


### PR DESCRIPTION
* Dry-run mode, when enabled with `-a` command line switch, will skip all MQTT calls, including connection and disconnection, as well as publishing messages. This is useful for testing the application without actually sending any data over MQTT
* One-shot and debug modes could now be enabled from command line with `-o` and `-d` switches respectively