### PR TITLE
fix: Properly collect Python dependencies during image build. Next attempt at build cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -173,5 +173,5 @@ jobs:
         run: >-
           docker run --rm
           --platform ${{ matrix.platform }}
-          ghcr.io/${{ github.repository }}:${{ needs.test.outputs.verions }}
+          ghcr.io/${{ github.repository }}:${{ needs.test.outputs.version }}
           --help

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -118,8 +118,11 @@ jobs:
       matrix:
         include:
           - platform: linux/arm/v7
+            cache_tag: linux-arm-v7
           - platform: linux/arm/v6
+            cache_tag: linux-arm-v6
           - platform: linux/arm64
+            cache_tag: linux-arm64
     runs-on: ubuntu-latest
     needs: [tests]
     permissions:
@@ -170,6 +173,6 @@ jobs:
             VERSION=${{ needs.tests.outputs.version }}
           # Cache the buildx cache between builds using GitHub registry
           cache-from: |
-            type=registry,ref=ghcr.io/${{ github.repository }}/buildcache:${{ matrix.platform }}
+            type=registry,ref=ghcr.io/${{ github.repository }}/buildcache:${{ matrix.cache_tag }}
           cache-to: |
-            type=registry,ref=ghcr.io/${{ github.repository }}/buildcache:${{ matrix.platform }},mode=max
+            type=registry,ref=ghcr.io/${{ github.repository }}/buildcache:${{ matrix.cache_tag }},mode=max

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -160,6 +160,8 @@ jobs:
 
       - name: Build and push images
         uses: docker/build-push-action@v6
+        env:
+          SETUPTOOLS_SCM_PRETEND_VERSION_ENERGOMERA_HASS_MQTT: ${{ needs.tests.outputs.version }}
         with:
           platforms: ${{ matrix.platform }}
           push: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,8 +104,7 @@ jobs:
     outputs:
       version: ${{ steps.meta.outputs.version }}
       labels: ${{ steps.meta.outputs.labels }}
-      annotations_json: ${{ toJson(fromJson(steps.meta.outputs.json).annotations) }}
-      tags_json: ${{ toJson(fromJson(steps.meta.outputs.json).tags) }}
+      json: ${{ steps.meta.outputs.json }}
     steps:
       - name: Prepare Docker metadata
         id: meta
@@ -206,14 +205,48 @@ jobs:
         with:
           matrix-step-name: docker-publish
 
+      - uses: actions/github-script@v7
+        id: buildx-imagetools-create-args
+        env:
+          JSON_METADATA: ${{ needs.docker-metadata.outputs.json }}
+        with:
+          result-encoding: string
+          script: |-
+            try {
+              const jsonMetadata = process.env.JSON_METADATA;
+              if (jsonMetadata === undefined) {
+                  throw new Error('JSON_METADATA is not defined');
+              }
+              const metadata = JSON.parse(jsonMetadata);
+
+              if (metadata.tags === undefined) {
+                  throw new Error("'tags' element is not defined in 'JSON_METADATA'");
+              }
+              const tagsArg = (metadata.tags || []).reduce((acc, item) => {
+                  acc += ` --tags ${item}`;
+                  return acc;
+              }, '');
+
+              if (metadata.annotations === undefined) {
+                  throw new Error("'annotations' element is not defined in 'JSON_METADATA'");
+              }
+              const annotationsArg = (metadata.annotations || []).reduce((acc, item) => {
+                  acc += ` --annotations '${item}'`;
+                  return acc;
+              }, '');
+
+              core.setOutput('result', `${tagsArg} ${annotationsArg}`);
+            } catch (e) {
+                core.setFailed(`Unable to construct arguments: ${e.message}`);
+            }
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Create and push Docker manifest
         run: >-
           docker buildx imagetools create
-          --annotation ${{ join(fromJson(needs.docker-metadata.outputs.annotations_json), ' --annotation ') }}
-          --tag ${{ join(fromJson(needs.docker-metadata.outputs.tags_json), ' --tag ') }}
+          ${{ steps.buildx-imagetools-create-args.outputs.result }}
           ${{ join(fromJson(steps.read.outputs.result).image_digest.*.value, ' ') }}
 
   docker-test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Build and push images
         uses: docker/build-push-action@v6
         env:
-          SETUPTOOLS_SCM_PRETEND_VERSION_ENERGOMERA_HASS_MQTT: ${{ needs.tests.outputs.version }}
+          SETUPTOOLS_SCM_PRETEND_VERSION_FOR_ENERGOMERA_HASS_MQTT: ${{ needs.tests.outputs.version }}
         with:
           platforms: ${{ matrix.platform }}
           push: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,11 +19,18 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
+        with:
+          # Disable shallow clone for `setuptools_scm`, as it needs access to the
+          # history
+          fetch-depth: 0
+
       - name: Set Python up
         uses: actions/setup-python@v5
+
       - name: Install dependencies
         run: >-
           python -m pip install --upgrade setuptools setuptools_scm
+
       - name: Determine package version
         id: package-version
         run: |
@@ -60,18 +67,23 @@ jobs:
           # Disable shallow clone for Sonar scanner, as it needs access to the
           # history
           fetch-depth: 0
+
       - name: Set Python up
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
+
       - name: Install testing tools
         run: >-
           python -m pip install --upgrade \
           setuptools setuptools_scm pip tox virtualenv coverage
+
       - name: Run the tests
         run: tox -e ${{ matrix.toxenv }}
+
       - name: Generage Coverage combined XML report
         run: coverage xml
+
       - name: SonarCloud scanning
         uses: sonarsource/sonarcloud-github-action@master
         env:
@@ -202,7 +214,7 @@ jobs:
           docker buildx imagetools create
           ${{ join(fromJson(needs.docker-metadata.outputs.annotations_json), '--annotation ') }}
           ${{ join(fromJson(needs.docker-metadata.outputs.tags_json), '--tags ') }}
-          ${{ join(fromJson(fromJson(steps.read.outputs.result).image_digest.*.value), ' ') }}
+          ${{ join(fromJson(steps.read.outputs.result).image_digest.*.value, ' ') }}
 
   docker-test:
     name: Test Docker images

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -152,7 +152,7 @@ jobs:
           type=registry,ref=ghcr.io/${{ github.repository }}/buildcache:${{ matrix.cache_tag }},mode=max
 
     - name: Store image information
-      uses: cloudposse/github-action-matrix-outputs-write@v1
+      uses: GoCodeAlone/github-action-matrix-outputs-write@v1
       id: out
       with:
         matrix-step-name: ${{ github.job }}
@@ -174,7 +174,7 @@ jobs:
           - platform: linux/arm/v6
     steps:
       - name: Read image information from publish job
-        uses: cloudposse/github-action-matrix-outputs-read@v1
+        uses: GoCodeAlone/github-action-matrix-outputs-read@v1
         id: read
         with:
           matrix-step-name: docker-publish

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -160,14 +160,14 @@ jobs:
 
       - name: Build and push images
         uses: docker/build-push-action@v6
-        env:
-          SETUPTOOLS_SCM_PRETEND_VERSION_FOR_ENERGOMERA_HASS_MQTT: ${{ needs.tests.outputs.version }}
         with:
           platforms: ${{ matrix.platform }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
+          build-arg: |
+            VERSION=${{ needs.tests.outputs.version }}
           # Cache the buildx cache between builds using GitHub registry
           cache-from: |
             type=registry,ref=ghcr.io/${{ github.repository }}/buildcache-${{ matrix.platform }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,6 +124,9 @@ jobs:
             type=edge
 
   docker-publish:
+    # The job uses platform as variations, since `buildx` can't properly cache
+    # those if done single shot (multiple platform specified to single command
+    # invocation)
     name: Build and publish Docker images
     strategy:
       fail-fast: false
@@ -197,6 +200,9 @@ jobs:
             value: ${{ steps.build.outputs.digest }}
 
   docker-manifest:
+    # The job uses image for for variations, hence each corresponding manifest
+    # is created separately - multiple tags in single command invocation might
+    # result in GHCR errors (not fully confirmed)
     name: Create and push Docker manifest
     runs-on: ubuntu-latest
     needs: [docker-metadata, docker-publish]
@@ -221,6 +227,8 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # The token above should have read/write access
+      # (`Settings` -> `Actions` -> `General` -> `Workflow permissions` -> `Read and write permissions`)
       - name: Create and push Docker manifest
         run: >-
           docker buildx imagetools create
@@ -244,18 +252,14 @@ jobs:
           - platform_id: linux/amd64
             platform_name: linux-amd64
     steps:
-      - name: Read image information from publish job
-        uses: GoCodeAlone/github-action-matrix-outputs-read@v1
-        id: read
-        with:
-          matrix-step-name: docker-publish
-
       - name: Set up QEMU for more platforms supported by Buildx
         uses: docker/setup-qemu-action@v3
         with:
           platforms: ${{ matrix.platform_id }}
 
-      - name: Test images
+      - name: Test the image
+        # Running the image with `--help` should be sufficient to ensure all
+        # dependencies are present
         run: >-
           docker run --rm
           --platform ${{ matrix.platform_id }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -212,8 +212,8 @@ jobs:
       - name: Create and push Docker manifest
         run: >-
           docker buildx imagetools create
-          ${{ join(fromJson(needs.docker-metadata.outputs.annotations_json), '--annotation ') }}
-          ${{ join(fromJson(needs.docker-metadata.outputs.tags_json), '--tags ') }}
+          --annotation ${{ join(fromJson(needs.docker-metadata.outputs.annotations_json), ' --annotation ') }}
+          --tag${{ join(fromJson(needs.docker-metadata.outputs.tags_json), ' --tag ') }}
           ${{ join(fromJson(steps.read.outputs.result).image_digest.*.value, ' ') }}
 
   docker-test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -240,6 +240,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create and push Docker manifest
         run: >-
           docker buildx imagetools create

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -154,7 +154,7 @@ jobs:
   docker-test:
     name: Test Docker images
     runs-on: ubuntu-latest
-    needs: [docker-publish]
+    needs: [tests, docker-publish]
     strategy:
       fail-fast: false
       matrix:
@@ -173,5 +173,5 @@ jobs:
         run: >-
           docker run --rm
           --platform ${{ matrix.platform }}
-          ghcr.io/${{ github.repository }}:${{ needs.docker-publish.outputs.verions }}
+          ghcr.io/${{ github.repository }}:${{ needs.test.outputs.verions }}
           --help

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -170,6 +170,6 @@ jobs:
             VERSION=${{ needs.tests.outputs.version }}
           # Cache the buildx cache between builds using GitHub registry
           cache-from: |
-            type=registry,ref=ghcr.io/${{ github.repository }}/buildcache-${{ matrix.platform }}
+            type=registry,ref=ghcr.io/${{ github.repository }}/buildcache:${{ matrix.platform }}
           cache-to: |
-            type=registry,ref=ghcr.io/${{ github.repository }}/buildcache-${{ matrix.platform }},mode=max
+            type=registry,ref=ghcr.io/${{ github.repository }}/buildcache:${{ matrix.platform }},mode=max

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -235,7 +235,7 @@ jobs:
                   return acc;
               }, '');
 
-              core.setOutput('result', `${tagsArg} ${annotationsArg}`);
+              return `${tagsArg} ${annotationsArg}`;
             } catch (e) {
                 core.setFailed(`Unable to construct arguments: ${e.message}`);
             }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -154,14 +154,23 @@ jobs:
       - name: Build and push images
         uses: docker/build-push-action@v6
         with:
+          # No explicit context used, since that makes cache misses most of the
+          # time, likely because of `version.txt` being unique on each build.
+          # See https://github.com/docker/build-push-action/issues/286 for more
+          # details
           platforms: linux/arm/v7,linux/arm/v6,linux/arm64,linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
+          # Implicit context points to working copy, not Git respository, so
+          # `setuptools_scm` needs to receive the version explicitly
           build-args: |
             VERSION=${{ needs.tests.outputs.version }}
-          # Cache the buildx cache between builds using GitHub registry
+          # Cache the buildx cache between builds using GitHub registry. `gha`
+          # cache has been mentioned to introduce cache misses for
+          # multi-platform builds, see https://github.com/docker/buildx/discussions/1382
+          # for potential hints
           cache-from: |
             type=registry,ref=ghcr.io/${{ github.repository }}/buildcache:latest
           cache-to: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -158,8 +158,8 @@ jobs:
         matrix-key: ${{ matrix.platform_name }}
         outputs: |-
           image_version: ${{ steps.meta.outputs.version }}
-          image_annotation: ${{ steps.meta.outputs.annotation }}
-          image_tags: ${{ steps.meta.outputs.tags }}
+          image_annotations: ${{ toJson(steps.meta.outputs.annotations) }}
+          image_tags: ${{ toJson(steps.meta.outputs.tags) }}
           image_digest: ${{ steps.build.outputs.digest }}
 
   docker-manifest:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,8 +106,6 @@ jobs:
       uses: docker/metadata-action@v5
       with:
         images: ghcr.io/${{ github.repository }}
-        flavor: |
-          suffix=-${{ matrix.platform_id }}
         tags: |
           type=pep440,pattern={{raw}},value=${{ needs.tests.outputs.version }}
           type=raw,value=latest,enable=${{
@@ -160,12 +158,35 @@ jobs:
         matrix-key: ${{ matrix.platform_name }}
         outputs: |-
           image_version: ${{ steps.meta.outputs.version }}
+          image_annotation: ${{ steps.meta.outputs.annotation }}
+          image_tags: ${{ steps.meta.outputs.tags }}
           image_digest: ${{ steps.build.outputs.digest }}
+
+  docker-manifest:
+    name: Create and push Docker manifest
+    runs-on: ubuntu-latest
+    needs: [docker-publish]
+    steps:
+      - name: Read image information from publish job
+        uses: GoCodeAlone/github-action-matrix-outputs-read@v1
+        id: read
+        with:
+          matrix-step-name: docker-publish
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Create and push Docker manifest
+        run: >-
+          docker buildx imagetools create
+          --annotation ${{ fromJson(steps.read.outputs.result).image_annotation[0] }}
+          ${{ join(fromJson(steps.read.outputs.result).image_tags, '--tags') }}
+          ${{ join(fromJson(steps.read.outputs.result).image_digest, ' ') }}
 
   docker-test:
     name: Test Docker images
     runs-on: ubuntu-latest
-    needs: [docker-publish]
+    needs: [docker-manifest]
     strategy:
       fail-fast: false
       matrix:
@@ -194,5 +215,5 @@ jobs:
         run: >-
           docker run --rm
           --platform ${{ matrix.platform_id }}
-          ghcr.io/${{ github.repository }}@${{ fromJson(steps.read.outputs.result).image_digest[matrix.platform_name] }}
+          ghcr.io/${{ github.repository }}:${{ fromJson(steps.read.outputs.result).image_version[0] }}
           --help

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,7 +166,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
-          build-arg: |
+          build-args: |
             VERSION=${{ needs.tests.outputs.version }}
           # Cache the buildx cache between builds using GitHub registry
           cache-from: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,16 +113,6 @@ jobs:
 
   docker-publish:
     name: Build and publish Docker images
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: linux/arm/v7
-            cache_tag: linux-arm-v7
-          - platform: linux/arm/v6
-            cache_tag: linux-arm-v6
-          - platform: linux/arm64
-            cache_tag: linux-arm64
     runs-on: ubuntu-latest
     needs: [tests]
     permissions:
@@ -143,8 +133,6 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}
-          flavor: |
-            suffix=-${{ matrix.platform }}
           tags: |
             type=pep440,pattern={{raw}},value=${{ needs.tests.outputs.version }}
             type=raw,value=latest,enable=${{
@@ -166,7 +154,7 @@ jobs:
       - name: Build and push images
         uses: docker/build-push-action@v6
         with:
-          platforms: ${{ matrix.platform }}
+          platforms: linux/arm/v7,linux/arm/v6,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -175,6 +163,6 @@ jobs:
             VERSION=${{ needs.tests.outputs.version }}
           # Cache the buildx cache between builds using GitHub registry
           cache-from: |
-            type=registry,ref=ghcr.io/${{ github.repository }}/buildcache:${{ matrix.cache_tag }}
+            type=registry,ref=ghcr.io/${{ github.repository }}/buildcache:latest
           cache-to: |
-            type=registry,ref=ghcr.io/${{ github.repository }}/buildcache:${{ matrix.cache_tag }},mode=max
+            type=registry,ref=ghcr.io/${{ github.repository }}/buildcache:latest,mode=max

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,7 @@ jobs:
             cache_tag: linux-amd64
     runs-on: ubuntu-latest
     outputs:
-      image_version_${{ matrix.platform }}: ${{ steps.meta.outputs.version }}
+      ${{ format('image_version_{0}', matrix.platform) }}: ${{ steps.meta.outputs.version }}
     needs: [tests]
     permissions:
       contents: read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,7 +98,7 @@ jobs:
           # yamllint enable rule:line-length
 
   docker-metadata:
-    name: Generata metadata for container images
+    name: Generate metadata for container images
     runs-on: ubuntu-latest
     needs: [version]
     outputs:
@@ -200,42 +200,16 @@ jobs:
     name: Create and push Docker manifest
     runs-on: ubuntu-latest
     needs: [docker-metadata, docker-publish]
+    strategy:
+      fail-fast: false
+      matrix:
+        tag: ${{ fromJson(needs.docker-metadata.outputs.json).tags }}
     steps:
       - name: Read image information from publish job
         uses: GoCodeAlone/github-action-matrix-outputs-read@v1
         id: read
         with:
           matrix-step-name: docker-publish
-
-      - name: Construct arguments for `docker buildx imagetools create` command
-        uses: actions/github-script@v7
-        id: buildx-imagetools-create-args
-        env:
-          JSON_METADATA: ${{ needs.docker-metadata.outputs.json }}
-        with:
-          result-encoding: string
-          script: |-
-            try {
-              const jsonMetadata = process.env.JSON_METADATA;
-              if (jsonMetadata === undefined) {
-                  throw new Error('JSON_METADATA is not defined');
-              }
-              const metadata = JSON.parse(jsonMetadata);
-
-              // Only tags are considered for the manifest, as annotations
-              // aren't currently supported there
-              if (metadata.tags === undefined) {
-                  throw new Error("'tags' element is not defined in 'JSON_METADATA'");
-              }
-              const tagsArg = (metadata.tags || []).reduce((acc, item) => {
-                  acc += ` --tag ${item}`;
-                  return acc;
-              }, '');
-
-              return tagsArg;
-            } catch (e) {
-                core.setFailed(`Unable to construct arguments: ${e.message}`);
-            }
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -250,7 +224,7 @@ jobs:
       - name: Create and push Docker manifest
         run: >-
           docker buildx imagetools create
-          ${{ steps.buildx-imagetools-create-args.outputs.result }}
+          --tag ${{ matrix.tag }}
           ${{ join(fromJson(steps.read.outputs.result).image_digest.*.value, ' ') }}
 
   docker-test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -160,6 +160,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
-          # Cache the buildx cache between builds using GitHub Actions cache
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Cache the buildx cache between builds using GitHub registry
+          cache-from: |
+            type=registry,ref=ghcr.io/${{ github.repository }}/buildcache
+          cache-to: |
+            type=registry,ref=ghcr.io/${{ github.repository }}/buildcache,mode=max

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,25 @@ on:
       - master
 
 jobs:
+  version:
+    name: Generate package version
+    runs-on: ubuntu-latest
+    outputs:
+      value: ${{ steps.package-version.outputs.value }}
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v4
+      - name: Set Python up
+        uses: actions/setup-python@v5
+      - name: Install dependencies
+        run: >-
+          python -m pip install --upgrade setuptools_scm
+      - name: Determine package version
+        id: package-version
+        run: |
+          package_version=`python -m setuptools_scm --format plain`
+          echo "value=$package_version" >> $GITHUB_OUTPUT
+
   tests:
     name: Tests
     strategy:
@@ -33,8 +52,7 @@ jobs:
             python: '3.12'
             toxenv: py
     runs-on: ${{ matrix.os }}
-    outputs:
-      version: ${{ steps.package-version.outputs.VALUE }}
+    needs: [version]
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
@@ -54,11 +72,6 @@ jobs:
         run: tox -e ${{ matrix.toxenv }}
       - name: Generage Coverage combined XML report
         run: coverage xml
-      - name: Determine package version
-        id: package-version
-        run: |
-          package_version=`python -m setuptools_scm --format plain`
-          echo "VALUE=$package_version" >> $GITHUB_OUTPUT
       - name: SonarCloud scanning
         uses: sonarsource/sonarcloud-github-action@master
         env:
@@ -69,8 +82,34 @@ jobs:
           args: >-
             -Dsonar.projectKey=${{ github.repository_owner }}_${{ github.event.repository.name }}
             -Dsonar.organization=${{ github.repository_owner }}
-            -Dsonar.projectVersion=${{ steps.package-version.outputs.VALUE }}
+            -Dsonar.projectVersion=${{ needs.version.outputs.value }}
           # yamllint enable rule:line-length
+
+  docker-metadata:
+    name: Generata metadata for container images
+    runs-on: ubuntu-latest
+    needs: [version]
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      labels: ${{ steps.meta.outputs.labels }}
+      annotations_json: ${{ toJson(fromJson(steps.meta.outputs.json).annotations) }}
+      tags_json: ${{ toJson(fromJson(steps.meta.outputs.json).tags) }}
+    steps:
+      - name: Prepare Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=pep440,pattern={{raw}},value=${{ needs.version.outputs.value }}
+            type=raw,value=latest,enable=${{
+              github.event_name == 'release'
+              && github.event.action == 'published'
+              && (github.event.release.target_commitish == 'main'
+              || github.event.release.target_commitish == 'master')
+            }}
+            type=ref,event=pr
+            type=edge
 
   docker-publish:
     name: Build and publish Docker images
@@ -87,7 +126,7 @@ jobs:
           - platform_id: linux/amd64
             platform_name: linux-amd64
     runs-on: ubuntu-latest
-    needs: [tests]
+    needs: [version, tests, docker-metadata]
     permissions:
       contents: read
       packages: write
@@ -100,22 +139,6 @@ jobs:
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
-
-    - name: Prepare Docker metadata
-      id: meta
-      uses: docker/metadata-action@v5
-      with:
-        images: ghcr.io/${{ github.repository }}
-        tags: |
-          type=pep440,pattern={{raw}},value=${{ needs.tests.outputs.version }}
-          type=raw,value=latest,enable=${{
-            github.event_name == 'release'
-            && github.event.action == 'published'
-            && (github.event.release.target_commitish == 'main'
-            || github.event.release.target_commitish == 'master')
-          }}
-          type=ref,event=pr
-          type=edge
 
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v3
@@ -133,11 +156,11 @@ jobs:
         # See https://github.com/docker/build-push-action/issues/286 for more
         # details
         platforms: ${{ matrix.platform_id }}
-        labels: ${{ steps.meta.outputs.labels }}
+        labels: ${{ needs.docker-metadata.outputs.labels }}
         # Implicit context points to working copy, not Git respository, so
         # `setuptools_scm` needs to receive the version explicitly
         build-args: |
-          VERSION=${{ needs.tests.outputs.version }}
+          VERSION=${{ needs.version.outputs.value }}
         # Push by digest only, manifest will be added later
         outputs: >-
           type=image,name=ghcr.io/${{ github.repository }},push-by-digest=true,name-canonical=true,push=true
@@ -157,15 +180,12 @@ jobs:
         matrix-step-name: ${{ github.job }}
         matrix-key: ${{ matrix.platform_name }}
         outputs: |-
-          image_version: ${{ steps.meta.outputs.version }}
-          image_annotations: ${{ toJson(fromJson(steps.meta.outputs.json).annotations) }}
-          image_tags: ${{ toJson(fromJson(steps.meta.outputs.json).tags) }}
           image_digest: ${{ steps.build.outputs.digest }}
 
   docker-manifest:
     name: Create and push Docker manifest
     runs-on: ubuntu-latest
-    needs: [docker-publish]
+    needs: [docker-metadata, docker-publish]
     steps:
       - name: Read image information from publish job
         uses: GoCodeAlone/github-action-matrix-outputs-read@v1
@@ -179,14 +199,14 @@ jobs:
       - name: Create and push Docker manifest
         run: >-
           docker buildx imagetools create
-          --annotation ${{ fromJson(fromJson(steps.read.outputs.result).image_annotations)[0] }}
-          ${{ join(fromJson(fromJson(steps.read.outputs.result).image_tags)[0], '--tags') }}
-          ${{ join(fromJson(fromJson(steps.read.outputs.result).image_digest), ' ') }}
+          ${{ join(fromJson(needs.docker-metadata.outputs.annotations_json), '--annotation ') }}
+          ${{ join(fromJson(needs.docker-metadata.outputs.tags_json), '--tags ') }}
+          ${{ join(fromJson(fromJson(steps.read.outputs.result).image_digest.*), ' ') }}
 
   docker-test:
     name: Test Docker images
     runs-on: ubuntu-latest
-    needs: [docker-manifest]
+    needs: [docker-metadata, docker-manifest]
     strategy:
       fail-fast: false
       matrix:
@@ -215,5 +235,5 @@ jobs:
         run: >-
           docker run --rm
           --platform ${{ matrix.platform_id }}
-          ghcr.io/${{ github.repository }}:${{ fromJson(steps.read.outputs.result).image_version[0] }}
+          ghcr.io/${{ github.repository }}:${{ needs.docker-metadata.outputs.version }}
           --help

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -173,5 +173,5 @@ jobs:
         run: >-
           docker run --rm
           --platform ${{ matrix.platform }}
-          ghcr.io/${{ github.repository }}:${{ needs.test.outputs.version }}
+          ghcr.io/${{ github.repository }}:${{ needs.tests.outputs.version }}
           --help

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,68 +74,80 @@ jobs:
 
   docker-publish:
     name: Build and publish Docker images
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/arm/v7
+            cache_tag: linux-arm-v7
+          - platform: linux/arm/v6
+            cache_tag: linux-arm-v6
+          - platform: linux/arm64
+            cache_tag: linux-arm64
     runs-on: ubuntu-latest
     needs: [tests]
     permissions:
       contents: read
       packages: write
     steps:
-      - name: Checkout the code
-        uses: actions/checkout@v3
+    - name: Checkout the code
+      uses: actions/checkout@v3
 
-      - name: Set up QEMU for more platforms supported by Buildx
-        uses: docker/setup-qemu-action@v3
+    - name: Set up QEMU for more platforms supported by Buildx
+      uses: docker/setup-qemu-action@v3
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
 
-      - name: Prepare Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/${{ github.repository }}
-          tags: |
-            type=pep440,pattern={{raw}},value=${{ needs.tests.outputs.version }}
-            type=raw,value=latest,enable=${{
-              github.event_name == 'release'
-              && github.event.action == 'published'
-              && (github.event.release.target_commitish == 'main'
-              || github.event.release.target_commitish == 'master')
-            }}
-            type=ref,event=pr
-            type=edge
+    - name: Prepare Docker metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ghcr.io/${{ github.repository }}
+        flavor: |
+          suffix=-${{ matrix.platform }}
+        tags: |
+          type=pep440,pattern={{raw}},value=${{ needs.tests.outputs.version }}
+          type=raw,value=latest,enable=${{
+            github.event_name == 'release'
+            && github.event.action == 'published'
+            && (github.event.release.target_commitish == 'main'
+            || github.event.release.target_commitish == 'master')
+          }}
+          type=ref,event=pr
+          type=edge
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push images
-        uses: docker/build-push-action@v6
-        with:
-          # No explicit context used, since that makes cache misses most of the
-          # time.
-          # See https://github.com/docker/build-push-action/issues/286 for more
-          # details
-          platforms: linux/arm/v7,linux/arm/v6,linux/arm64,linux/amd64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          annotations: ${{ steps.meta.outputs.annotations }}
-          # Implicit context points to working copy, not Git respository, so
-          # `setuptools_scm` needs to receive the version explicitly
-          build-args: |
-            VERSION=${{ needs.tests.outputs.version }}
-          # Cache the buildx cache between builds using GitHub registry. `gha`
-          # cache has been mentioned to introduce cache misses for
-          # multi-platform builds, see https://github.com/docker/buildx/discussions/1382
-          # for potential hints
-          cache-from: |
-            type=registry,ref=ghcr.io/${{ github.repository }}/buildcache:latest
-          cache-to: |
-            type=registry,ref=ghcr.io/${{ github.repository }}/buildcache:latest,mode=max
+    - name: Build and push images
+      uses: docker/build-push-action@v6
+      with:
+        # No explicit context used, since that makes cache misses most of the
+        # time.
+        # See https://github.com/docker/build-push-action/issues/286 for more
+        # details
+        platforms: ${{ matrix.platform }}
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        annotations: ${{ steps.meta.outputs.annotations }}
+        # Implicit context points to working copy, not Git respository, so
+        # `setuptools_scm` needs to receive the version explicitly
+        build-args: |
+          VERSION=${{ needs.tests.outputs.version }}
+        # Cache the buildx cache between builds using GitHub registry. `gha`
+        # cache has been mentioned to introduce cache misses for
+        # multi-platform builds, see https://github.com/docker/buildx/discussions/1382
+        # for potential hints
+        cache-from: |
+          type=registry,ref=ghcr.io/${{ github.repository }}/buildcache:${{ matrix.cache_tag }}
+        cache-to: |
+          type=registry,ref=ghcr.io/${{ github.repository }}/buildcache:${{ matrix.cache_tag }},mode=max
 
   docker-test:
     name: Test Docker images

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,8 +87,6 @@ jobs:
           - platform: linux/amd64
             cache_tag: linux-amd64
     runs-on: ubuntu-latest
-    outputs:
-      ${{ format('image_version_{0}', matrix.platform) }}: ${{ steps.meta.outputs.version }}
     needs: [tests]
     permissions:
       contents: read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -161,7 +161,6 @@ jobs:
       - name: Build and push images
         uses: docker/build-push-action@v6
         with:
-          context: .
           platforms: ${{ matrix.platform }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -136,3 +136,28 @@ jobs:
             type=registry,ref=ghcr.io/${{ github.repository }}/buildcache:latest
           cache-to: |
             type=registry,ref=ghcr.io/${{ github.repository }}/buildcache:latest,mode=max
+
+  docker-test:
+    name: Test Docker images
+    runs-on: ubuntu-latest
+    needs: [docker-publish]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/arm64
+          - platform: linux/amd64
+          - platform: linux/arm/v7
+          - platform: linux/arm/v6
+    steps:
+      - name: Set up QEMU for more platforms supported by Buildx
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: ${{ matrix.platform }}
+
+      - name: Test images
+        run: >-
+          docker run --rm
+          --platform ${{ matrix.platform }}
+          ghcr.io/${{ github.repository }}:${{ needs.docker-publish.outputs.verions }}
+          --help

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,46 +72,6 @@ jobs:
             -Dsonar.projectVersion=${{ steps.package-version.outputs.VALUE }}
           # yamllint enable rule:line-length
 
-  pypi-publish:
-    name: Publish to PyPi
-    runs-on: ubuntu-latest
-    # PyPi disallows to publish packages with direct dependencies (GitHub
-    # sourced dependency in this case), so disable publishing for now
-    if: false
-    needs: [tests]
-    steps:
-      - name: Checkout the code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0  # `setuptools_scm` needs tags
-      - name: Set Python up
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.9
-      - name: Install the PEP517 package builder
-        run: python -m pip install --upgrade build
-      - name: Build the package
-        run: python -m build
-      - name: Publish the package to Test PyPi
-        # Skip publishing to test PyPI if we're performing release, there might
-        # be already the version of the package from the merge to master branch
-        if: github.event_name != 'release'
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.TEST_PYPI_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
-      - name: Publish the release to PyPi
-        # Publish to production PyPi only happens when a release published out
-        # of the main branch
-        if: >-
-          github.event_name == 'release'
-          && github.event.action == 'published'
-          && (github.event.release.target_commitish == 'main'
-             || github.event.release.target_commitish == 'master')
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_TOKEN }}
-
   docker-publish:
     name: Build and publish Docker images
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,8 +143,10 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}
+          flavor: |
+            suffix=-${{ matrix.platform }}
           tags: |
-            type=pep440,pattern={{raw}},value=${{ needs.tests.outputs.version }}-${{ matrix.platform }}
+            type=pep440,pattern={{raw}},value=${{ needs.tests.outputs.version }}
             type=raw,value=latest,enable=${{
               github.event_name == 'release'
               && github.event.action == 'published'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,8 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Install testing tools
         run: >-
-          python -m pip install --upgrade setuptools pip tox virtualenv coverage
+          python -m pip install --upgrade \
+          setuptools setuptools_scm pip tox virtualenv coverage
       - name: Run the tests
         run: tox -e ${{ matrix.toxenv }}
       - name: Generage Coverage combined XML report
@@ -56,7 +57,7 @@ jobs:
       - name: Determine package version
         id: package-version
         run: |
-          package_version=`cat version.txt`
+          package_version=`python -m setuptools_scm --format plain`
           echo "VALUE=$package_version" >> $GITHUB_OUTPUT
       - name: SonarCloud scanning
         uses: sonarsource/sonarcloud-github-action@master
@@ -155,7 +156,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           # No explicit context used, since that makes cache misses most of the
-          # time, likely because of `version.txt` being unique on each build.
+          # time.
           # See https://github.com/docker/build-push-action/issues/286 for more
           # details
           platforms: linux/arm/v7,linux/arm/v6,linux/arm64,linux/amd64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -213,7 +213,7 @@ jobs:
         run: >-
           docker buildx imagetools create
           --annotation ${{ join(fromJson(needs.docker-metadata.outputs.annotations_json), ' --annotation ') }}
-          --tag${{ join(fromJson(needs.docker-metadata.outputs.tags_json), ' --tag ') }}
+          --tag ${{ join(fromJson(needs.docker-metadata.outputs.tags_json), ' --tag ') }}
           ${{ join(fromJson(steps.read.outputs.result).image_digest.*.value, ' ') }}
 
   docker-test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -158,8 +158,8 @@ jobs:
         matrix-key: ${{ matrix.platform_name }}
         outputs: |-
           image_version: ${{ steps.meta.outputs.version }}
-          image_annotations: ${{ toJson(steps.meta.outputs.annotations) }}
-          image_tags: ${{ toJson(steps.meta.outputs.tags) }}
+          image_annotations: ${{ steps.meta.outputs.json.annotations }}
+          image_tags: ${{ steps.meta.outputs.json.tags }}
           image_digest: ${{ steps.build.outputs.digest }}
 
   docker-manifest:
@@ -179,8 +179,8 @@ jobs:
       - name: Create and push Docker manifest
         run: >-
           docker buildx imagetools create
-          --annotation ${{ fromJson(steps.read.outputs.result).image_annotation[0] }}
-          ${{ join(fromJson(steps.read.outputs.result).image_tags, '--tags') }}
+          --annotation ${{ fromJson(steps.read.outputs.result).image_annotations[0] }}
+          ${{ join(fromJson(steps.read.outputs.result).image_tags[0], '--tags') }}
           ${{ join(fromJson(steps.read.outputs.result).image_digest, ' ') }}
 
   docker-test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,6 +113,13 @@ jobs:
 
   docker-publish:
     name: Build and publish Docker images
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/arm/v7
+          - platform: linux/arm/v6
+          - platform: linux/arm64
     runs-on: ubuntu-latest
     needs: [tests]
     permissions:
@@ -132,7 +139,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ghcr.io/${{ github.repository }}-${{ matrix.platform }}
           tags: |
             type=pep440,pattern={{raw}},value=${{ needs.tests.outputs.version }}
             type=raw,value=latest,enable=${{
@@ -155,13 +162,13 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/arm/v7,linux/arm/v6,linux/arm64
+          platforms: ${{ matrix.platform }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
           # Cache the buildx cache between builds using GitHub registry
           cache-from: |
-            type=registry,ref=ghcr.io/${{ github.repository }}/buildcache
+            type=registry,ref=ghcr.io/${{ github.repository }}/buildcache-${{ matrix.platform }}
           cache-to: |
-            type=registry,ref=ghcr.io/${{ github.repository }}/buildcache,mode=max
+            type=registry,ref=ghcr.io/${{ github.repository }}/buildcache-${{ matrix.platform }},mode=max

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -194,5 +194,5 @@ jobs:
         run: >-
           docker run --rm
           --platform ${{ matrix.platform_id }}
-          ghcr.io/${{ github.repository }}:${{ fromJson(steps.read.outputs.result).image_digest[matrix.platform_name] }}
+          ghcr.io/${{ github.repository }}@${{ fromJson(steps.read.outputs.result).image_digest[matrix.platform_name] }}
           --help

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,6 +84,8 @@ jobs:
             cache_tag: linux-arm-v6
           - platform: linux/arm64
             cache_tag: linux-arm64
+          - platform: linux/amd64
+            cache_tag: linux-amd64
     runs-on: ubuntu-latest
     needs: [tests]
     permissions:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,7 @@ jobs:
             cache_tag: linux-amd64
     runs-on: ubuntu-latest
     outputs:
-      image_version: ${{ steps.meta.outputs.version }}
+      image_version_${{ matrix.platform }}: ${{ steps.meta.outputs.version }}
     needs: [tests]
     permissions:
       contents: read
@@ -175,5 +175,5 @@ jobs:
         run: >-
           docker run --rm
           --platform ${{ matrix.platform }}
-          ghcr.io/${{ github.repository }}:${{ needs.docker-publish.outputs.image_version }}
+          ghcr.io/${{ github.repository }}:${{ fromJSON(needs.docker-publish.outputs)[image_version_${{ matrix.platform }}] }}
           --help

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-python@v5
       - name: Install dependencies
         run: >-
-          python -m pip install --upgrade setuptools_scm
+          python -m pip install --upgrade setuptools setuptools_scm
       - name: Determine package version
         id: package-version
         run: |
@@ -180,7 +180,8 @@ jobs:
         matrix-step-name: ${{ github.job }}
         matrix-key: ${{ matrix.platform_name }}
         outputs: |-
-          image_digest: ${{ steps.build.outputs.digest }}
+          image_digest:
+            value: ${{ steps.build.outputs.digest }}
 
   docker-manifest:
     name: Create and push Docker manifest
@@ -201,7 +202,7 @@ jobs:
           docker buildx imagetools create
           ${{ join(fromJson(needs.docker-metadata.outputs.annotations_json), '--annotation ') }}
           ${{ join(fromJson(needs.docker-metadata.outputs.tags_json), '--tags ') }}
-          ${{ join(fromJson(fromJson(steps.read.outputs.result).image_digest.*), ' ') }}
+          ${{ join(fromJson(fromJson(steps.read.outputs.result).image_digest.*.value), ' ') }}
 
   docker-test:
     name: Test Docker images

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -205,7 +205,8 @@ jobs:
         with:
           matrix-step-name: docker-publish
 
-      - uses: actions/github-script@v7
+      - name: Construct arguments for `docker buildx imagetools create` command
+        uses: actions/github-script@v7
         id: buildx-imagetools-create-args
         env:
           JSON_METADATA: ${{ needs.docker-metadata.outputs.json }}
@@ -223,7 +224,7 @@ jobs:
                   throw new Error("'tags' element is not defined in 'JSON_METADATA'");
               }
               const tagsArg = (metadata.tags || []).reduce((acc, item) => {
-                  acc += ` --tags ${item}`;
+                  acc += ` --tag ${item}`;
                   return acc;
               }, '');
 
@@ -231,7 +232,7 @@ jobs:
                   throw new Error("'annotations' element is not defined in 'JSON_METADATA'");
               }
               const annotationsArg = (metadata.annotations || []).reduce((acc, item) => {
-                  acc += ` --annotations '${item}'`;
+                  acc += ` --annotation '${item}'`;
                   return acc;
               }, '');
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -128,6 +128,7 @@ jobs:
 
     - name: Build and push images
       uses: docker/build-push-action@v6
+      id: build
       with:
         # No explicit context used, since that makes cache misses most of the
         # time.
@@ -158,7 +159,9 @@ jobs:
         matrix-step-name: ${{ github.job }}
         matrix-key: ${{ matrix.platform_name }}
         outputs: |-
-          image: ghcr.io/${{ github.repository }}:${{ steps.meta.outputs.version }}
+          image_version: ${{ steps.meta.outputs.version }}
+          image_digest: ${{ steps.build.outputs.digest }}
+          image_id: ${{ steps.build.outputs.imageid }}
 
   docker-test:
     name: Test Docker images
@@ -192,5 +195,5 @@ jobs:
         run: >-
           docker run --rm
           --platform ${{ matrix.platform_id }}
-          ghcr.io/${{ github.repository }}:${{ fromJson(steps.read.outputs.result).image[matrix.platform_name] }}
+          ghcr.io/${{ github.repository }}:${{ fromJson(steps.read.outputs.result).image_version[matrix.platform_name] }}
           --help

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,14 +78,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: linux/arm/v7
-            cache_tag: linux-arm-v7
-          - platform: linux/arm/v6
-            cache_tag: linux-arm-v6
-          - platform: linux/arm64
-            cache_tag: linux-arm64
-          - platform: linux/amd64
-            cache_tag: linux-amd64
+          - platform_id: linux/arm/v7
+            platform_name: linux-arm-v7
+          - platform_id: linux/arm/v6
+            platform_name: linux-arm-v6
+          - platform_id: linux/arm64
+            platform_name: linux-arm64
+          - platform_id: linux/amd64
+            platform_name: linux-amd64
     runs-on: ubuntu-latest
     needs: [tests]
     permissions:
@@ -107,7 +107,7 @@ jobs:
       with:
         images: ghcr.io/${{ github.repository }}
         flavor: |
-          suffix=-${{ matrix.platform }}
+          suffix=-${{ matrix.platform_id }}
         tags: |
           type=pep440,pattern={{raw}},value=${{ needs.tests.outputs.version }}
           type=raw,value=latest,enable=${{
@@ -133,7 +133,7 @@ jobs:
         # time.
         # See https://github.com/docker/build-push-action/issues/286 for more
         # details
-        platforms: ${{ matrix.platform }}
+        platforms: ${{ matrix.platform_id }}
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
@@ -147,16 +147,16 @@ jobs:
         # multi-platform builds, see https://github.com/docker/buildx/discussions/1382
         # for potential hints
         cache-from: |
-          type=registry,ref=ghcr.io/${{ github.repository }}/buildcache:${{ matrix.cache_tag }}
+          type=registry,ref=ghcr.io/${{ github.repository }}/buildcache:${{ matrix.platform_name }}
         cache-to: |
-          type=registry,ref=ghcr.io/${{ github.repository }}/buildcache:${{ matrix.cache_tag }},mode=max
+          type=registry,ref=ghcr.io/${{ github.repository }}/buildcache:${{ matrix.platform_name }},mode=max
 
     - name: Store image information
       uses: GoCodeAlone/github-action-matrix-outputs-write@v1
       id: out
       with:
         matrix-step-name: ${{ github.job }}
-        matrix-key: ${{ matrix.platform }}
+        matrix-key: ${{ matrix.platform_name }}
         outputs: |-
           image: ghcr.io/${{ github.repository }}:${{ steps.meta.outputs.version }}
 
@@ -168,10 +168,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: linux/arm64
-          - platform: linux/amd64
-          - platform: linux/arm/v7
-          - platform: linux/arm/v6
+          - platform_id: linux/arm/v7
+            platform_name: linux-arm-v7
+          - platform_id: linux/arm/v6
+            platform_name: linux-arm-v6
+          - platform_id: linux/arm64
+            platform_name: linux-arm64
+          - platform_id: linux/amd64
+            platform_name: linux-amd64
     steps:
       - name: Read image information from publish job
         uses: GoCodeAlone/github-action-matrix-outputs-read@v1
@@ -182,11 +186,11 @@ jobs:
       - name: Set up QEMU for more platforms supported by Buildx
         uses: docker/setup-qemu-action@v3
         with:
-          platforms: ${{ matrix.platform }}
+          platforms: ${{ matrix.platform_id }}
 
       - name: Test images
         run: >-
           docker run --rm
-          --platform ${{ matrix.platform }}
-          ghcr.io/${{ github.repository }}:${{ fromJson(steps.read.outputs.result).image[matrix.platform] }}
+          --platform ${{ matrix.platform_id }}
+          ghcr.io/${{ github.repository }}:${{ fromJson(steps.read.outputs.result).image[matrix.platform_name] }}
           --help

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -142,9 +142,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository }}-${{ matrix.platform }}
+          images: ghcr.io/${{ github.repository }}
           tags: |
-            type=pep440,pattern={{raw}},value=${{ needs.tests.outputs.version }}
+            type=pep440,pattern={{raw}},value=${{ needs.tests.outputs.version }}-${{ matrix.platform }}
             type=raw,value=latest,enable=${{
               github.event_name == 'release'
               && github.event.action == 'published'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -158,8 +158,8 @@ jobs:
         matrix-key: ${{ matrix.platform_name }}
         outputs: |-
           image_version: ${{ steps.meta.outputs.version }}
-          image_annotations: ${{ steps.meta.outputs.json.annotations }}
-          image_tags: ${{ steps.meta.outputs.json.tags }}
+          image_annotations: ${{ toJson(fromJson(steps.meta.outputs.json).annotations) }}
+          image_tags: ${{ toJson(fromJson(steps.meta.outputs.json).tags) }}
           image_digest: ${{ steps.build.outputs.digest }}
 
   docker-manifest:
@@ -179,9 +179,9 @@ jobs:
       - name: Create and push Docker manifest
         run: >-
           docker buildx imagetools create
-          --annotation ${{ fromJson(steps.read.outputs.result).image_annotations[0] }}
-          ${{ join(fromJson(steps.read.outputs.result).image_tags[0], '--tags') }}
-          ${{ join(fromJson(steps.read.outputs.result).image_digest, ' ') }}
+          --annotation ${{ fromJson(fromJson(steps.read.outputs.result).image_annotations)[0] }}
+          ${{ join(fromJson(fromJson(steps.read.outputs.result).image_tags)[0], '--tags') }}
+          ${{ join(fromJson(fromJson(steps.read.outputs.result).image_digest), ' ') }}
 
   docker-test:
     name: Test Docker images

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,6 +104,7 @@ jobs:
     outputs:
       version: ${{ steps.meta.outputs.version }}
       labels: ${{ steps.meta.outputs.labels }}
+      annotations: ${{ steps.meta.outputs.annotations }}
       json: ${{ steps.meta.outputs.json }}
     steps:
       - name: Prepare Docker metadata
@@ -168,6 +169,7 @@ jobs:
         # details
         platforms: ${{ matrix.platform_id }}
         labels: ${{ needs.docker-metadata.outputs.labels }}
+        annotations: ${{ needs.docker-metadata.outputs.annotations }}
         # Implicit context points to working copy, not Git respository, so
         # `setuptools_scm` needs to receive the version explicitly
         build-args: |
@@ -220,6 +222,8 @@ jobs:
               }
               const metadata = JSON.parse(jsonMetadata);
 
+              // Only tags are considered for the manifest, as annotations
+              // aren't currently supported there
               if (metadata.tags === undefined) {
                   throw new Error("'tags' element is not defined in 'JSON_METADATA'");
               }
@@ -228,15 +232,7 @@ jobs:
                   return acc;
               }, '');
 
-              if (metadata.annotations === undefined) {
-                  throw new Error("'annotations' element is not defined in 'JSON_METADATA'");
-              }
-              const annotationsArg = (metadata.annotations || []).reduce((acc, item) => {
-                  acc += ` --annotation '${item}'`;
-                  return acc;
-              }, '');
-
-              return `${tagsArg} ${annotationsArg}`;
+              return tagsArg;
             } catch (e) {
                 core.setFailed(`Unable to construct arguments: ${e.message}`);
             }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,13 +37,13 @@ jobs:
       version: ${{ steps.package-version.outputs.VALUE }}
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Disable shallow clone for Sonar scanner, as it needs access to the
           # history
           fetch-depth: 0
       - name: Set Python up
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
       - name: Install testing tools
@@ -87,13 +87,15 @@ jobs:
           - platform: linux/amd64
             cache_tag: linux-amd64
     runs-on: ubuntu-latest
+    outputs:
+      image_version: ${{ steps.meta.outputs.version }}
     needs: [tests]
     permissions:
       contents: read
       packages: write
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up QEMU for more platforms supported by Buildx
       uses: docker/setup-qemu-action@v3
@@ -120,7 +122,7 @@ jobs:
           type=edge
 
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
@@ -154,7 +156,7 @@ jobs:
   docker-test:
     name: Test Docker images
     runs-on: ubuntu-latest
-    needs: [tests, docker-publish]
+    needs: [docker-publish]
     strategy:
       fail-fast: false
       matrix:
@@ -173,5 +175,5 @@ jobs:
         run: >-
           docker run --rm
           --platform ${{ matrix.platform }}
-          ghcr.io/${{ github.repository }}:${{ needs.tests.outputs.version }}
+          ghcr.io/${{ github.repository }}:${{ needs.docker-publish.outputs.image_version }}
           --help

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -135,14 +135,14 @@ jobs:
         # See https://github.com/docker/build-push-action/issues/286 for more
         # details
         platforms: ${{ matrix.platform_id }}
-        push: true
-        tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
-        annotations: ${{ steps.meta.outputs.annotations }}
         # Implicit context points to working copy, not Git respository, so
         # `setuptools_scm` needs to receive the version explicitly
         build-args: |
           VERSION=${{ needs.tests.outputs.version }}
+        # Push by digest only, manifest will be added later
+        outputs: >-
+          type=image,name=ghcr.io/${{ github.repository }},push-by-digest=true,name-canonical=true,push=true
         # Cache the buildx cache between builds using GitHub registry. `gha`
         # cache has been mentioned to introduce cache misses for
         # multi-platform builds, see https://github.com/docker/buildx/discussions/1382
@@ -161,7 +161,6 @@ jobs:
         outputs: |-
           image_version: ${{ steps.meta.outputs.version }}
           image_digest: ${{ steps.build.outputs.digest }}
-          image_id: ${{ steps.build.outputs.imageid }}
 
   docker-test:
     name: Test Docker images
@@ -195,5 +194,5 @@ jobs:
         run: >-
           docker run --rm
           --platform ${{ matrix.platform_id }}
-          ghcr.io/${{ github.repository }}:${{ fromJson(steps.read.outputs.result).image_version[matrix.platform_name] }}
+          ghcr.io/${{ github.repository }}:${{ fromJson(steps.read.outputs.result).image_digest[matrix.platform_name] }}
           --help

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -154,7 +154,7 @@ jobs:
       - name: Build and push images
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/arm/v7,linux/arm/v6,linux/arm64
+          platforms: linux/arm/v7,linux/arm/v6,linux/arm64,linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -153,6 +153,15 @@ jobs:
         cache-to: |
           type=registry,ref=ghcr.io/${{ github.repository }}/buildcache:${{ matrix.cache_tag }},mode=max
 
+    - name: Store image information
+      uses: cloudposse/github-action-matrix-outputs-write@v1
+      id: out
+      with:
+        matrix-step-name: ${{ github.job }}
+        matrix-key: ${{ matrix.platform }}
+        outputs: |-
+          image: ghcr.io/${{ github.repository }}:${{ steps.meta.outputs.version }}
+
   docker-test:
     name: Test Docker images
     runs-on: ubuntu-latest
@@ -166,6 +175,12 @@ jobs:
           - platform: linux/arm/v7
           - platform: linux/arm/v6
     steps:
+      - name: Read image information from publish job
+        uses: cloudposse/github-action-matrix-outputs-read@v1
+        id: read
+        with:
+          matrix-step-name: docker-publish
+
       - name: Set up QEMU for more platforms supported by Buildx
         uses: docker/setup-qemu-action@v3
         with:
@@ -175,5 +190,5 @@ jobs:
         run: >-
           docker run --rm
           --platform ${{ matrix.platform }}
-          ghcr.io/${{ github.repository }}:${{ fromJSON(needs.docker-publish.outputs)[image_version_${{ matrix.platform }}] }}
+          ghcr.io/${{ github.repository }}:${{ fromJson(steps.read.outputs.result).image[matrix.platform] }}
           --help

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ FROM python:3.12.5-alpine
 COPY --from=build \
 	/usr/src/target/root/.local/lib/ /usr/local/lib/
 COPY --from=build \
-	/usr/src/target/root/.local/bin/ \
+	/usr/src/target/usr/local/bin/ \
 	/usr/local/bin/
 
 ENTRYPOINT ["energomera-hass-mqtt"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM python:3.12.5-alpine AS build
-ARG VERSION
 COPY . /usr/src/
 WORKDIR /usr/src/
 # Rust and Cargo are required to build `pyndatic-core` on ARM platforms
@@ -9,6 +8,7 @@ RUN apk add -U cargo git rust \
 # Install dependencies in a separate layer to cache them
 RUN pip install --root target/ -r requirements.txt
 # Build the package
+ARG VERSION
 RUN SETUPTOOLS_SCM_PRETEND_VERSION_FOR_ENERGOMERA_HASS_MQTT=${VERSION} python -m build \
 	&& pip install --root target/ dist/*-`cat version.txt`*.whl
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.12.5-alpine AS build
+ARG VERSION
 COPY . /usr/src/
 WORKDIR /usr/src/
 # Rust and Cargo are required to build `pyndatic-core` on ARM platforms
@@ -8,7 +9,7 @@ RUN apk add -U cargo git rust \
 # Install dependencies in a separate layer to cache them
 RUN pip install --root target/ -r requirements.txt
 # Build the package
-RUN python -m build \
+RUN SETUPTOOLS_SCM_PRETEND_VERSION_FOR_ENERGOMERA_HASS_MQTT=${VERSION} python -m build \
 	&& pip install --root target/ dist/*-`cat version.txt`*.whl
 
 FROM python:3.12.5-alpine

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ RUN apk add -U cargo git rust \
 	&& pip install build \
 	&& apk cache clean
 # Install dependencies in a separate layer to cache them
-RUN --mount=type=cache,target=/root/.cache/pip pip install --root target/ -r requirements.txt
+RUN pip install --root target/ -r requirements.txt
 # Build the package
-RUN --mount=type=cache,target=/root/.cache/pip python -m build \
+RUN python -m build \
 	&& pip install --root target/ dist/*-`cat version.txt`*.whl
 
 FROM python:3.12.5-alpine

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
 FROM python:3.12.5-alpine AS build
+
+ARG VERSION
+RUN test -z "${VERSION}" && echo "No 'VERSION' argument provided, exiting" \
+	&& exit 1 || true
+
 COPY . /usr/src/
 WORKDIR /usr/src/
+
 # Rust and Cargo are required to build `pyndatic-core` on ARM platforms
 RUN apk add -U cargo git rust \
 	&& pip install build \
@@ -8,9 +14,9 @@ RUN apk add -U cargo git rust \
 # Install dependencies in a separate layer to cache them
 RUN pip install --root target/ -r requirements.txt
 # Build the package
-ARG VERSION
+
 RUN SETUPTOOLS_SCM_PRETEND_VERSION_FOR_ENERGOMERA_HASS_MQTT=${VERSION} python -m build \
-	&& pip install --root target/ dist/*-`cat version.txt`*.whl
+	&& pip install --root target/ dist/*-${VERSION}*.whl
 
 FROM python:3.12.5-alpine
 COPY --from=build \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ ARG VERSION
 RUN test -z "${VERSION}" && echo "No 'VERSION' argument provided, exiting" \
 	&& exit 1 || true
 
+# Writeable mount is needed for src/*.egg-info the `setup` module wants to
+# create
 RUN --mount=type=bind,target=source/,rw SETUPTOOLS_SCM_PRETEND_VERSION_FOR_ENERGOMERA_HASS_MQTT=${VERSION} python -m build --outdir /tmp/dist/ source/ \
 	&& pip install --root /tmp/target/ /tmp/dist/*-${VERSION}*.whl
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,12 @@ FROM python:3.12.5-alpine AS deps
 RUN apk add -U cargo git rust \
 	&& pip install build \
 	&& apk cache clean
+
+# Limit use of the build context to the requirements file only, to avoid cache
+# invalidation when other files get changed
+COPY requirements.txt .
 # Install dependencies in a separate layer to cache them
-RUN --mount=type=bind,target=source/ pip install --root /tmp/target/ -r source/requirements.txt
+RUN pip install --root /tmp/target/ -r requirements.txt
 
 FROM python:3.12.5-alpine AS build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,9 @@ RUN SETUPTOOLS_SCM_PRETEND_VERSION_FOR_ENERGOMERA_HASS_MQTT=${VERSION} python -m
 
 FROM python:3.12.5-alpine
 COPY --from=build \
-	/usr/src/target/root/.local/lib/ /usr/local/lib/
+	/usr/src/target/root/.local/lib/ \
+	/usr/src/target/usr/local/lib/ \
+	/usr/local/lib/
 COPY --from=build \
 	/usr/src/target/usr/local/bin/ \
 	/usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ RUN apk add -U cargo git rust \
 	&& pip install build \
 	&& apk cache clean
 # Install dependencies in a separate layer to cache them
-RUN --mount=type=cache,target=/root/.cache/pip pip install -r requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip pip install --root target/ -r requirements.txt
 # Build the package
-RUN python -m build \
+RUN --mount=type=cache,target=/root/.cache/pip python -m build \
 	&& pip install --root target/ dist/*-`cat version.txt`*.whl
 
 FROM python:3.12.5-alpine

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,5 @@
 FROM python:3.12.5-alpine AS build
 
-ARG VERSION
-RUN test -z "${VERSION}" && echo "No 'VERSION' argument provided, exiting" \
-	&& exit 1 || true
-
 COPY . /usr/src/
 WORKDIR /usr/src/
 
@@ -14,6 +10,10 @@ RUN apk add -U cargo git rust \
 # Install dependencies in a separate layer to cache them
 RUN pip install --root target/ -r requirements.txt
 # Build the package
+
+ARG VERSION
+RUN test -z "${VERSION}" && echo "No 'VERSION' argument provided, exiting" \
+	&& exit 1 || true
 
 RUN SETUPTOOLS_SCM_PRETEND_VERSION_FOR_ENERGOMERA_HASS_MQTT=${VERSION} python -m build \
 	&& pip install --root target/ dist/*-${VERSION}*.whl

--- a/README.rst
+++ b/README.rst
@@ -43,12 +43,15 @@ Usage
 
 .. code::
 
-   usage: energomera-hass-mqtt [-h] [-c CONFIG_FILE]
+   usage: energomera-hass-mqtt [-h] [-c CONFIG_FILE] [-a] [-d] [-o]
 
-   optional arguments:
-    -h, --help            show this help message and exit
-    -c CONFIG_FILE, --config-file CONFIG_FILE
-       Path to configuration file (default: '/etc/energomera/config.yaml')
+   options:
+   -h, --help            show this help message and exit
+   -c CONFIG_FILE, --config-file CONFIG_FILE
+                           Path to configuration file (default: '/etc/energomera/config.yaml')
+   -a, --dry-run         Dry run, do not actually send any data
+   -d, --debug           Enable debug logging
+   -o, --one-shot        Run only once, then exit
 
 Configuration file format
 =========================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 local_scheme = "no-local-version"
-write_to = "version.txt"
 
 [tool.pytest.ini_options]
 pythonpath = [


### PR DESCRIPTION
* `Dockerfile`: fixed installing Python package dependencies
* `Dockerfile`: restructured to minimize chances of cache invalidation
* Github Actions: switched to `registry` cache for Docker build, as `gha` might reduce hit ratio (see https://github.com/docker/buildx/discussions/1382 for details)
* Github Actions: to improve caching the image for each platform is built separately, single `buildx` invocation with multiple platforms doesn't result in proper caching (see the link above for details)
* Github Actions: added step to test resulting images