### PR TITLE
fix: Use `default_entity_id` instead of deprecated `object_id` in Home Assistant MQTT discovery

### DIFF
--- a/src/energomera_hass_mqtt/iec_hass_sensor.py
+++ b/src/energomera_hass_mqtt/iec_hass_sensor.py
@@ -198,7 +198,9 @@ class IecToHassSensor:  # pylint: disable=too-many-instance-attributes
             ),
             device_class=self._config_param.device_class,
             unique_id=self._hass_unique_id,
-            object_id=self._hass_unique_id,
+            # `object_id` is now deprecated, use `default_entity_id` instead.
+            # See https://github.com/home-assistant/core/pull/151775 for details
+            default_entity_id=self._hass_unique_id,
             unit_of_measurement=self._config_param.unit,
             state_class=self._config_param.state_class,
             state_topic=self._hass_state_topic,

--- a/src/energomera_hass_mqtt/iec_hass_sensor.py
+++ b/src/energomera_hass_mqtt/iec_hass_sensor.py
@@ -199,7 +199,8 @@ class IecToHassSensor:  # pylint: disable=too-many-instance-attributes
             device_class=self._config_param.device_class,
             unique_id=self._hass_unique_id,
             # `object_id` is now deprecated, use `default_entity_id` instead.
-            # See https://github.com/home-assistant/core/pull/151775 for details
+            # See https://github.com/home-assistant/core/pull/151775 for
+            # details
             default_entity_id=self._hass_unique_id,
             unit_of_measurement=self._config_param.unit,
             state_class=self._config_param.state_class,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -203,7 +203,7 @@ MQTT_PUBLISH_CALLS_COMPLETE = [
                 },
                 'device_class': 'energy',
                 'unique_id': 'CE301_00123456_ET0PE',
-                'object_id': 'CE301_00123456_ET0PE',
+                'default_entity_id': 'CE301_00123456_ET0PE',
                 'unit_of_measurement': 'kWh',
                 'state_class': 'total_increasing',
                 'state_topic': 'homeassistant/sensor/CE301_00123456'
@@ -231,7 +231,7 @@ MQTT_PUBLISH_CALLS_COMPLETE = [
                 },
                 'device_class': 'energy',
                 'unique_id': 'CE301_00123456_ECMPE',
-                'object_id': 'CE301_00123456_ECMPE',
+                'default_entity_id': 'CE301_00123456_ECMPE',
                 'unit_of_measurement': 'kWh',
                 'state_class': 'total',
                 'state_topic': 'homeassistant/sensor/CE301_00123456'
@@ -259,7 +259,7 @@ MQTT_PUBLISH_CALLS_COMPLETE = [
                 },
                 'device_class': 'energy',
                 'unique_id': 'CE301_00123456_ENMPE_PREV_MONTH',
-                'object_id': 'CE301_00123456_ENMPE_PREV_MONTH',
+                'default_entity_id': 'CE301_00123456_ENMPE_PREV_MONTH',
                 'unit_of_measurement': 'kWh',
                 'state_class': 'total_increasing',
                 'state_topic': 'homeassistant/sensor/CE301_00123456'
@@ -288,7 +288,7 @@ MQTT_PUBLISH_CALLS_COMPLETE = [
                 },
                 'device_class': 'energy',
                 'unique_id': 'CE301_00123456_ECMPE_PREV_MONTH',
-                'object_id': 'CE301_00123456_ECMPE_PREV_MONTH',
+                'default_entity_id': 'CE301_00123456_ECMPE_PREV_MONTH',
                 'unit_of_measurement': 'kWh',
                 'state_class': 'total',
                 'state_topic': 'homeassistant/sensor/CE301_00123456'
@@ -317,7 +317,7 @@ MQTT_PUBLISH_CALLS_COMPLETE = [
                 },
                 'device_class': 'energy',
                 'unique_id': 'CE301_00123456_ECDPE',
-                'object_id': 'CE301_00123456_ECDPE',
+                'default_entity_id': 'CE301_00123456_ECDPE',
                 'unit_of_measurement': 'kWh',
                 'state_class': 'total',
                 'state_topic': 'homeassistant/sensor/CE301_00123456'
@@ -345,7 +345,7 @@ MQTT_PUBLISH_CALLS_COMPLETE = [
                 },
                 'device_class': 'power',
                 'unique_id': 'CE301_00123456_POWPP_0',
-                'object_id': 'CE301_00123456_POWPP_0',
+                'default_entity_id': 'CE301_00123456_POWPP_0',
                 'unit_of_measurement': 'kW',
                 'state_class': 'measurement',
                 'state_topic': 'homeassistant/sensor/CE301_00123456'
@@ -374,7 +374,7 @@ MQTT_PUBLISH_CALLS_COMPLETE = [
                 },
                 'device_class': 'power',
                 'unique_id': 'CE301_00123456_POWPP_1',
-                'object_id': 'CE301_00123456_POWPP_1',
+                'default_entity_id': 'CE301_00123456_POWPP_1',
                 'unit_of_measurement': 'kW',
                 'state_class': 'measurement',
                 'state_topic': 'homeassistant/sensor/CE301_00123456'
@@ -403,7 +403,7 @@ MQTT_PUBLISH_CALLS_COMPLETE = [
                 },
                 'device_class': 'power',
                 'unique_id': 'CE301_00123456_POWPP_2',
-                'object_id': 'CE301_00123456_POWPP_2',
+                'default_entity_id': 'CE301_00123456_POWPP_2',
                 'unit_of_measurement': 'kW',
                 'state_class': 'measurement',
                 'state_topic': 'homeassistant/sensor/CE301_00123456'
@@ -432,7 +432,7 @@ MQTT_PUBLISH_CALLS_COMPLETE = [
                 },
                 'device_class': 'power',
                 'unique_id': 'CE301_00123456_POWEP',
-                'object_id': 'CE301_00123456_POWEP',
+                'default_entity_id': 'CE301_00123456_POWEP',
                 'unit_of_measurement': 'kW',
                 'state_class': 'measurement',
                 'state_topic': 'homeassistant/sensor/CE301_00123456'
@@ -460,7 +460,7 @@ MQTT_PUBLISH_CALLS_COMPLETE = [
                 },
                 'device_class': 'voltage',
                 'unique_id': 'CE301_00123456_VOLTA_0',
-                'object_id': 'CE301_00123456_VOLTA_0',
+                'default_entity_id': 'CE301_00123456_VOLTA_0',
                 'unit_of_measurement': 'V',
                 'state_class': 'measurement',
                 'state_topic': 'homeassistant/sensor/CE301_00123456'
@@ -489,7 +489,7 @@ MQTT_PUBLISH_CALLS_COMPLETE = [
                 },
                 'device_class': 'voltage',
                 'unique_id': 'CE301_00123456_VOLTA_1',
-                'object_id': 'CE301_00123456_VOLTA_1',
+                'default_entity_id': 'CE301_00123456_VOLTA_1',
                 'unit_of_measurement': 'V',
                 'state_class': 'measurement',
                 'state_topic': 'homeassistant/sensor/CE301_00123456'
@@ -518,7 +518,7 @@ MQTT_PUBLISH_CALLS_COMPLETE = [
                 },
                 'device_class': 'voltage',
                 'unique_id': 'CE301_00123456_VOLTA_2',
-                'object_id': 'CE301_00123456_VOLTA_2',
+                'default_entity_id': 'CE301_00123456_VOLTA_2',
                 'unit_of_measurement': 'V',
                 'state_class': 'measurement',
                 'state_topic': 'homeassistant/sensor/CE301_00123456'
@@ -547,7 +547,7 @@ MQTT_PUBLISH_CALLS_COMPLETE = [
                 },
                 'device_class': 'voltage',
                 'unique_id': 'CE301_00123456_VNULL',
-                'object_id': 'CE301_00123456_VNULL',
+                'default_entity_id': 'CE301_00123456_VNULL',
                 'unit_of_measurement': 'V',
                 'state_class': 'measurement',
                 'state_topic': 'homeassistant/sensor/CE301_00123456'
@@ -575,7 +575,7 @@ MQTT_PUBLISH_CALLS_COMPLETE = [
                 },
                 'device_class': 'current',
                 'unique_id': 'CE301_00123456_CURRE_0',
-                'object_id': 'CE301_00123456_CURRE_0',
+                'default_entity_id': 'CE301_00123456_CURRE_0',
                 'unit_of_measurement': 'A',
                 'state_class': 'measurement',
                 'state_topic': 'homeassistant/sensor/CE301_00123456'
@@ -604,7 +604,7 @@ MQTT_PUBLISH_CALLS_COMPLETE = [
                 },
                 'device_class': 'current',
                 'unique_id': 'CE301_00123456_CURRE_1',
-                'object_id': 'CE301_00123456_CURRE_1',
+                'default_entity_id': 'CE301_00123456_CURRE_1',
                 'unit_of_measurement': 'A',
                 'state_class': 'measurement',
                 'state_topic': 'homeassistant/sensor/CE301_00123456'
@@ -633,7 +633,7 @@ MQTT_PUBLISH_CALLS_COMPLETE = [
                 },
                 'device_class': 'current',
                 'unique_id': 'CE301_00123456_CURRE_2',
-                'object_id': 'CE301_00123456_CURRE_2',
+                'default_entity_id': 'CE301_00123456_CURRE_2',
                 'unit_of_measurement': 'A',
                 'state_class': 'measurement',
                 'state_topic': 'homeassistant/sensor/CE301_00123456'
@@ -662,7 +662,7 @@ MQTT_PUBLISH_CALLS_COMPLETE = [
                 },
                 'device_class': 'frequency',
                 'unique_id': 'CE301_00123456_FREQU',
-                'object_id': 'CE301_00123456_FREQU',
+                'default_entity_id': 'CE301_00123456_FREQU',
                 'unit_of_measurement': 'Hz',
                 'state_class': 'measurement',
                 'state_topic': 'homeassistant/sensor/CE301_00123456'
@@ -692,7 +692,7 @@ MQTT_PUBLISH_CALLS_COMPLETE = [
                 },
                 'device_class': 'current',
                 'unique_id': 'CE301_00123456_CURRE_INDEXED_0',
-                'object_id': 'CE301_00123456_CURRE_INDEXED_0',
+                'default_entity_id': 'CE301_00123456_CURRE_INDEXED_0',
                 'unit_of_measurement': 'A',
                 'state_class': 'measurement',
                 'state_topic': 'homeassistant/sensor/CE301_00123456'
@@ -721,7 +721,7 @@ MQTT_PUBLISH_CALLS_COMPLETE = [
                 },
                 'device_class': 'current',
                 'unique_id': 'CE301_00123456_CURRE_INDEXED_1',
-                'object_id': 'CE301_00123456_CURRE_INDEXED_1',
+                'default_entity_id': 'CE301_00123456_CURRE_INDEXED_1',
                 'unit_of_measurement': 'A',
                 'state_class': 'measurement',
                 'state_topic': 'homeassistant/sensor/CE301_00123456'
@@ -750,7 +750,7 @@ MQTT_PUBLISH_CALLS_COMPLETE = [
                 },
                 'device_class': 'current',
                 'unique_id': 'CE301_00123456_CURRE_INDEXED_2',
-                'object_id': 'CE301_00123456_CURRE_INDEXED_2',
+                'default_entity_id': 'CE301_00123456_CURRE_INDEXED_2',
                 'unit_of_measurement': 'A',
                 'state_class': 'measurement',
                 'state_topic': 'homeassistant/sensor/CE301_00123456'
@@ -780,7 +780,7 @@ MQTT_PUBLISH_CALLS_COMPLETE = [
                 },
                 'device_class': 'current',
                 'unique_id': 'CE301_00123456_CURRE_INDEXED_FALLBACK_0',
-                'object_id': 'CE301_00123456_CURRE_INDEXED_FALLBACK_0',
+                'default_entity_id': 'CE301_00123456_CURRE_INDEXED_FALLBACK_0',
                 'unit_of_measurement': 'A',
                 'state_class': 'measurement',
                 'state_topic': 'homeassistant/sensor/CE301_00123456'
@@ -810,7 +810,7 @@ MQTT_PUBLISH_CALLS_COMPLETE = [
                 },
                 'device_class': 'current',
                 'unique_id': 'CE301_00123456_CURRE_INDEXED_FALLBACK_1',
-                'object_id': 'CE301_00123456_CURRE_INDEXED_FALLBACK_1',
+                'default_entity_id': 'CE301_00123456_CURRE_INDEXED_FALLBACK_1',
                 'unit_of_measurement': 'A',
                 'state_class': 'measurement',
                 'state_topic': 'homeassistant/sensor/CE301_00123456'
@@ -840,7 +840,7 @@ MQTT_PUBLISH_CALLS_COMPLETE = [
                 },
                 'device_class': 'current',
                 'unique_id': 'CE301_00123456_CURRE_INDEXED_FALLBACK_2',
-                'object_id': 'CE301_00123456_CURRE_INDEXED_FALLBACK_2',
+                'default_entity_id': 'CE301_00123456_CURRE_INDEXED_FALLBACK_2',
                 'unit_of_measurement': 'A',
                 'state_class': 'measurement',
                 'state_topic': 'homeassistant/sensor/CE301_00123456'
@@ -870,7 +870,7 @@ MQTT_PUBLISH_CALLS_COMPLETE = [
                 },
                 'device_class': 'connectivity',
                 'unique_id': 'CE301_00123456_IS_ONLINE',
-                'object_id': 'CE301_00123456_IS_ONLINE',
+                'default_entity_id': 'CE301_00123456_IS_ONLINE',
                 'state_topic': 'homeassistant/binary_sensor/CE301_00123456'
                                '/CE301_00123456_IS_ONLINE'
                                '/state',
@@ -897,7 +897,7 @@ MQTT_PUBLISH_CALLS_COMPLETE = [
                     'sw_version': '12'
                 },
                 'unique_id': 'CE301_00123456_CYCLE_DURATION',
-                'object_id': 'CE301_00123456_CYCLE_DURATION',
+                'default_entity_id': 'CE301_00123456_CYCLE_DURATION',
                 'unit_of_measurement': 's',
                 'state_topic': 'homeassistant/sensor/CE301_00123456/'
                                'CE301_00123456_CYCLE_DURATION/state',

--- a/tests/test_config_payload_update.py
+++ b/tests/test_config_payload_update.py
@@ -98,7 +98,7 @@ def test_config_payload_update(
                     },
                     'device_class': 'energy',
                     'unique_id': 'CE301_00123456_ET0PE',
-                    'object_id': 'CE301_00123456_ET0PE',
+                    'default_entity_id': 'CE301_00123456_ET0PE',
                     'unit_of_measurement': 'kWh',
                     'state_class': 'total_increasing',
                     'state_topic': 'homeassistant/sensor/CE301_00123456'
@@ -125,7 +125,7 @@ def test_config_payload_update(
                     },
                     'device_class': 'energy',
                     'unique_id': 'CE301_00123456_ET0PE',
-                    'object_id': 'CE301_00123456_ET0PE',
+                    'default_entity_id': 'CE301_00123456_ET0PE',
                     'unit_of_measurement': 'kWh',
                     'state_class': 'total_increasing',
                     'state_topic': 'homeassistant/sensor/CE301_00123456'


### PR DESCRIPTION
* HASS ([PR 151775](https://github.com/home-assistant/core/pull/151775)) deprecates `object_id` in favor of `default_entity_id` for MQTT discovery messages, the code is updated accordingly.