### PR TITLE
feat!: Remove Python 3.9 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,9 +44,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python: 3.9
-            toxenv: py
-          - os: ubuntu-latest
             python: '3.10'
             toxenv: py
           - os: ubuntu-latest

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,5 @@
 sphinx-rtd-theme
-sphinx-autodoc-typehints==2.3.0; python_version < '3.11'
-sphinx-autodoc-typehints==3.10.2; python_version >= '3.11'
+sphinx-autodoc-typehints==3.10.2
 -r ../requirements.txt
 urllib3>=2.7.0 # not directly required, pinned by Snyk to avoid a vulnerability
 zipp>=3.23.1 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,20 +1,14 @@
 -r requirements.txt
 check-manifest==0.51
 flake8==7.3.0
-pylint==3.3.9; python_version < '3.10'
-pylint==4.0.5; python_version >= '3.10'
-pytest==8.4.2; python_version < '3.10'
-pytest==9.0.3; python_version >= '3.10'
-pytest-asyncio==1.2.0; python_version < '3.10'
-pytest-asyncio==1.3.0; python_version >= '3.10'
+pylint==4.0.5
+pytest==9.0.3
+pytest-asyncio==1.3.0
 pytest-cov==7.1.0
 freezegun==1.5.5
-mypy==1.19.1; python_version < '3.10'
-mypy==2.1.0; python_version >= '3.10'
-types-python-dateutil==2.9.0.20260124; python_version < '3.10'
-types-python-dateutil==2.9.0.20260518; python_version >= '3.10'
-types-PyYAML==6.0.12.20250915; python_version < '3.10'
-types-PyYAML==6.0.12.20260518; python_version >= '3.10'
+mypy==2.1.0
+types-python-dateutil==2.9.0.20260518
+types-PyYAML==6.0.12.20260518
 callee==0.3.1
 setuptools>=70.0.0 # not directly required, pinned by Snyk to avoid a vulnerability
 zipp>=3.23.1 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,19 +16,19 @@ classifiers =
 	Topic :: Home Automation
 	Topic :: System :: Hardware
 	License :: OSI Approved :: MIT License
-	Programming Language :: Python :: 3
 	Programming Language :: Python :: 3.9
 	Programming Language :: Python :: 3.10
 	Programming Language :: Python :: 3.11
   Programming Language :: Python :: 3.12
   Programming Language :: Python :: 3.13
+  Programming Language :: Python :: 3.14
 	Programming Language :: Python :: 3 :: Only
 
 [options]
 package_dir =
 	= src
 packages = find:
-python_requires = >=3.9
+python_requires = >=3.10
 install_requires = file:requirements.txt
 
 [options.packages.find]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{39,310,311,312,313,314}
+envlist = py{310,311,312,313,314}
 
 # Define the minimal tox version required to run;
 # if the host tox is less than this the tool with create an environment and


### PR DESCRIPTION
Python 3.9 reached end of life at Oct 2025 and most of the dependencies are not updated for it, hence the package no longer supports it officially