### PR TITLE
feat: Add per-parameter abs_value conversion for meter readings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -129,6 +129,11 @@ Configuration file is in YAML format and supports following elements:
               response_idx:
               # (string) - optional: Category of the HASS sensor entity
               entity_category:
+              # (bool) - optional, default ``false``: Convert the numeric value
+              #  from the meter to its absolute representation. The original
+              #  raw value is exposed as a HASS sensor attribute ``raw_value``.
+              #  Non-numeric values log a warning and are left unchanged
+              abs_value:
 
 
 Interpolation expressions

--- a/src/energomera_hass_mqtt/const.py
+++ b/src/energomera_hass_mqtt/const.py
@@ -58,7 +58,7 @@ DEFAULT_CONFIG_PARAMETERS = [
         unit='kWh',
         response_idx=0,
         additional_data=None,
-        entity_name=None
+        entity_name=None,
     ),
     dict(
         address='ECMPE',
@@ -68,7 +68,8 @@ DEFAULT_CONFIG_PARAMETERS = [
         unit='kWh',
         response_idx=0,
         additional_data=None,
-        entity_name=None),
+        entity_name=None,
+    ),
     dict(
         address='ENMPE',
         name='Cumulative energy, previous month',
@@ -77,7 +78,7 @@ DEFAULT_CONFIG_PARAMETERS = [
         unit='kWh',
         response_idx=0,
         additional_data='{{ energomera_prev_month }}',
-        entity_name='ENMPE_PREV_MONTH'
+        entity_name='ENMPE_PREV_MONTH',
     ),
     dict(
         address='EAMPE',
@@ -87,7 +88,7 @@ DEFAULT_CONFIG_PARAMETERS = [
         unit='kWh',
         response_idx=0,
         additional_data='{{ energomera_prev_month }}',
-        entity_name='ECMPE_PREV_MONTH'
+        entity_name='ECMPE_PREV_MONTH',
     ),
     dict(
         address='ECDPE',
@@ -97,7 +98,7 @@ DEFAULT_CONFIG_PARAMETERS = [
         unit='kWh',
         response_idx=0,
         additional_data=None,
-        entity_name=None
+        entity_name=None,
     ),
     dict(
         address='POWPP',
@@ -111,7 +112,8 @@ DEFAULT_CONFIG_PARAMETERS = [
         unit='kW',
         response_idx=None,
         additional_data=None,
-        entity_name=None
+        entity_name=None,
+        abs_value=True,
     ),
     dict(
         address='POWEP',
@@ -121,7 +123,8 @@ DEFAULT_CONFIG_PARAMETERS = [
         unit='kW',
         response_idx=None,
         additional_data=None,
-        entity_name=None
+        entity_name=None,
+        abs_value=True,
     ),
     dict(
         address='VOLTA',
@@ -135,7 +138,8 @@ DEFAULT_CONFIG_PARAMETERS = [
         unit='V',
         response_idx=None,
         additional_data=None,
-        entity_name=None
+        entity_name=None,
+        abs_value=True,
     ),
     dict(
         address='VNULL',
@@ -145,7 +149,8 @@ DEFAULT_CONFIG_PARAMETERS = [
         unit='V',
         response_idx=None,
         additional_data=None,
-        entity_name=None
+        entity_name=None,
+        abs_value=True,
     ),
     dict(
         address='CURRE',
@@ -159,7 +164,8 @@ DEFAULT_CONFIG_PARAMETERS = [
         unit='A',
         response_idx=None,
         additional_data=None,
-        entity_name=None
+        entity_name=None,
+        abs_value=True,
     ),
     dict(
         address='FREQU',
@@ -169,6 +175,7 @@ DEFAULT_CONFIG_PARAMETERS = [
         unit='Hz',
         response_idx=None,
         additional_data=None,
-        entity_name=None
+        entity_name=None,
+        abs_value=True,
     ),
 ]

--- a/src/energomera_hass_mqtt/iec_hass_sensor.py
+++ b/src/energomera_hass_mqtt/iec_hass_sensor.py
@@ -24,16 +24,18 @@ protocol.
 """
 from __future__ import annotations
 from typing import (
-    Dict, TYPE_CHECKING, Optional, Union, Collection, List
+    Dict, TYPE_CHECKING, Optional, Union, Collection, List, Tuple
 )
 import json
 import logging
+import re
 if TYPE_CHECKING:
     from .schema import ConfigMqttSchema, ConfigParameterSchema
     from .mqtt_client import MqttClient
     from iec62056_21.messages import DataSet as IecDataSet
 
 _LOGGER = logging.getLogger(__name__)
+_INTEGER_RE = re.compile(r'[+-]?\d+$')
 
 
 class IecToHassSensor:  # pylint: disable=too-many-instance-attributes
@@ -123,6 +125,33 @@ class IecToHassSensor:  # pylint: disable=too-many-instance-attributes
                               self._config_param.response_idx, self.iec_item)
                 self.iec_item = []
 
+    def apply_abs_value(self, value: str) -> Tuple[str, Optional[str]]:
+        """
+        Converts a numeric value to its absolute representation when
+        ``abs_value`` is enabled for the parameter.
+
+        :param value: Raw value received from the meter
+        :return: Tuple of (possibly converted value, original raw value or
+         ``None`` when conversion was not applied)
+        """
+        if not self._config_param.abs_value:
+            return value, None
+
+        try:
+            if _INTEGER_RE.fullmatch(value):
+                converted = str(abs(int(value)))
+            else:
+                converted = str(abs(float(value)))
+        except (TypeError, ValueError):
+            _LOGGER.warning(
+                "Cannot apply abs_value to non-numeric value '%s'"
+                " at address '%s', using original value",
+                value, self._config_param.address
+            )
+            return value, None
+
+        return converted, value
+
     def hass_gen_hass_sensor_props(self, idx: int) -> None:
         """
         Generates various properties for the HASS sensor (device and unique
@@ -208,20 +237,31 @@ class IecToHassSensor:  # pylint: disable=too-many-instance-attributes
             entity_category=self._config_param.entity_category,
             value_template='{{ value_json.value }}',
         )
+        if self._config_param.abs_value:
+            res['json_attributes_topic'] = self._hass_state_topic
+            res['json_attributes_template'] = (
+                "{{ {'raw_value': value_json.raw_value} | tojson }}"
+            )
         # Skip empty values
         return {k: v for k, v in res.items() if v is not None}
 
     def hass_state_payload(  # pylint: disable=no-self-use
-        self, value: str
+        self, value: str, raw_value: Optional[str] = None
     ) -> Dict[str, str]:
         """
         Returns HASS state payload for the item.
 
+        :param value: Sensor state value
+        :param raw_value: Optional original raw value exposed as a HASS
+         attribute
         :return: HASS state payload
         """
-        return dict(
+        res = dict(
             value=value
         )
+        if raw_value is not None:
+            res['raw_value'] = raw_value
+        return res
 
     async def process(self, setup_only: bool = False) -> None:
         """
@@ -308,8 +348,9 @@ class IecToHassSensor:  # pylint: disable=too-many-instance-attributes
                                   self._hass_config_topic)
 
                 # Sensor state payload
+                value, raw_value = self.apply_abs_value(iec_value.value)
                 state_payload = self.hass_state_payload(
-                    value=iec_value.value
+                    value=value, raw_value=raw_value
                 )
                 json_state_payload = json.dumps(state_payload)
                 _LOGGER.debug("MQTT state payload for HASS auto-discovery:"

--- a/src/energomera_hass_mqtt/iec_hass_sensor.py
+++ b/src/energomera_hass_mqtt/iec_hass_sensor.py
@@ -217,26 +217,26 @@ class IecToHassSensor:  # pylint: disable=too-many-instance-attributes
             and self._hass_unique_id and self._hass_state_topic
         ), 'HASS item properties are missing'
 
-        res = dict(
-            name=self._hass_item_name,
-            device=dict(
-                name=self._serial_number,
-                ids=self._hass_device_id,
-                model=self._model,
-                sw_version=self._sw_version,
-            ),
-            device_class=self._config_param.device_class,
-            unique_id=self._hass_unique_id,
+        res = {
+            'name': self._hass_item_name,
+            'device': {
+                'name': self._serial_number,
+                'ids': self._hass_device_id,
+                'model': self._model,
+                'sw_version': self._sw_version,
+            },
+            'device_class': self._config_param.device_class,
+            'unique_id': self._hass_unique_id,
             # `object_id` is now deprecated, use `default_entity_id` instead.
             # See https://github.com/home-assistant/core/pull/151775 for
             # details
-            default_entity_id=self._hass_unique_id,
-            unit_of_measurement=self._config_param.unit,
-            state_class=self._config_param.state_class,
-            state_topic=self._hass_state_topic,
-            entity_category=self._config_param.entity_category,
-            value_template='{{ value_json.value }}',
-        )
+            'default_entity_id': self._hass_unique_id,
+            'unit_of_measurement': self._config_param.unit,
+            'state_class': self._config_param.state_class,
+            'state_topic': self._hass_state_topic,
+            'entity_category': self._config_param.entity_category,
+            'value_template': '{{ value_json.value }}',
+        }
         if self._config_param.abs_value:
             res['json_attributes_topic'] = self._hass_state_topic
             res['json_attributes_template'] = (
@@ -256,9 +256,7 @@ class IecToHassSensor:  # pylint: disable=too-many-instance-attributes
          attribute
         :return: HASS state payload
         """
-        res = dict(
-            value=value
-        )
+        res = {'value': value}
         if raw_value is not None:
             res['raw_value'] = raw_value
         return res

--- a/src/energomera_hass_mqtt/schema.py
+++ b/src/energomera_hass_mqtt/schema.py
@@ -96,6 +96,7 @@ class ConfigParameterSchema(BaseModel):
     entity_name: Optional[str] = None
     response_idx: Optional[int] = None
     entity_category: Optional[str] = None
+    abs_value: bool = False
 
 
 class ConfigSchema(BaseModel):

--- a/tests/test_abs_value.py
+++ b/tests/test_abs_value.py
@@ -1,0 +1,227 @@
+# Copyright (c) 2026 Ilia Sotnikov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+'''
+Tests for per-parameter abs_value conversion.
+'''
+from __future__ import annotations
+from typing import Any, Dict, List
+import json
+import logging
+from unittest.mock import call
+import pytest
+from conftest import (
+    CONFIG_YAML_BASE, MockMqttT, SERIAL_EXCHANGE_BASE
+)
+from energomera_hass_mqtt.main import main
+
+POWEP_REQUEST: Dict[str, bytes] = {
+    'receive_bytes': b'\x01R1\x02POWEP()\x03d',
+}
+
+
+def _config_yaml(abs_value: bool) -> str:
+    abs_value_yaml = 'true' if abs_value else 'false'
+    return CONFIG_YAML_BASE + f'''
+    parameters:
+        - address: POWEP
+          device_class: power
+          name: Active power abs
+          state_class: measurement
+          unit: kW
+          abs_value: {abs_value_yaml}
+'''
+
+
+def _serial_exchange(value: str) -> List[Dict[str, bytes]]:
+    responses = {
+        '-1.2345': b'\x02POWEP(-1.2345)\r\n\x03P',
+        '-42': b'\x02POWEP(-42)\r\n\x03\t',
+        'not-a-number': b'\x02POWEP(not-a-number)\r\n\x03\x0b',
+        '-0.5266': b'\x02POWEP(-0.5266)\r\n\x03T',
+    }
+    return SERIAL_EXCHANGE_BASE + [
+        {
+            **POWEP_REQUEST,
+            'send_bytes': responses[value],
+        },
+    ]
+
+
+def _config_payload(*, with_attributes: bool) -> Dict[str, Any]:
+    payload = {
+        'name': 'Active power abs',
+        'device': {
+            'name': '00123456',
+            'ids': 'CE301_00123456',
+            'model': 'CE301',
+            'sw_version': '12',
+        },
+        'device_class': 'power',
+        'unique_id': 'CE301_00123456_POWEP',
+        'default_entity_id': 'CE301_00123456_POWEP',
+        'unit_of_measurement': 'kW',
+        'state_class': 'measurement',
+        'state_topic': (
+            'homeassistant/sensor/CE301_00123456'
+            '/CE301_00123456_POWEP/state'
+        ),
+        'value_template': '{{ value_json.value }}',
+    }
+    if with_attributes:
+        payload['json_attributes_topic'] = (
+            'homeassistant/sensor/CE301_00123456'
+            '/CE301_00123456_POWEP/state'
+        )
+        payload['json_attributes_template'] = (
+            "{{ {'raw_value': value_json.raw_value} | tojson }}"
+        )
+    return payload
+
+
+@pytest.mark.usefixtures('mock_config', 'mock_serial')
+@pytest.mark.config_yaml(_config_yaml(True))
+@pytest.mark.serial_exchange(_serial_exchange('-1.2345'))
+def test_abs_value_float(mock_mqtt: MockMqttT) -> None:
+    '''
+    Tests abs_value conversion for a negative float reading.
+    '''
+    main()
+    mock_mqtt['publish'].assert_has_calls([
+        call(
+            topic=(
+                'homeassistant/sensor/CE301_00123456'
+                '/CE301_00123456_POWEP/config'
+            ),
+            payload=json.dumps(_config_payload(with_attributes=True)),
+            retain=True,
+        ),
+        call(
+            topic=(
+                'homeassistant/sensor/CE301_00123456'
+                '/CE301_00123456_POWEP/state'
+            ),
+            payload=json.dumps({
+                'value': '1.2345',
+                'raw_value': '-1.2345',
+            }),
+        ),
+    ])
+
+
+@pytest.mark.usefixtures('mock_config', 'mock_serial')
+@pytest.mark.config_yaml(_config_yaml(True))
+@pytest.mark.serial_exchange(_serial_exchange('-42'))
+def test_abs_value_integer(mock_mqtt: MockMqttT) -> None:
+    '''
+    Tests abs_value conversion for a negative integer reading.
+    '''
+    main()
+    mock_mqtt['publish'].assert_has_calls([
+        call(
+            topic=(
+                'homeassistant/sensor/CE301_00123456'
+                '/CE301_00123456_POWEP/config'
+            ),
+            payload=json.dumps(_config_payload(with_attributes=True)),
+            retain=True,
+        ),
+        call(
+            topic=(
+                'homeassistant/sensor/CE301_00123456'
+                '/CE301_00123456_POWEP/state'
+            ),
+            payload=json.dumps({
+                'value': '42',
+                'raw_value': '-42',
+            }),
+        ),
+    ])
+
+
+@pytest.mark.usefixtures('mock_config', 'mock_serial')
+@pytest.mark.config_yaml(_config_yaml(True))
+@pytest.mark.serial_exchange(_serial_exchange('not-a-number'))
+def test_abs_value_non_numeric(
+    mock_mqtt: MockMqttT, caplog: pytest.LogCaptureFixture
+) -> None:
+    '''
+    Tests abs_value on a non-numeric reading logs a warning and keeps the
+    original value without aborting the cycle.
+    '''
+    with caplog.at_level(logging.WARNING):
+        main()
+
+    assert any(
+        "Cannot apply abs_value to non-numeric value 'not-a-number'" in msg
+        for msg in caplog.messages
+    )
+    mock_mqtt['publish'].assert_has_calls([
+        call(
+            topic=(
+                'homeassistant/sensor/CE301_00123456'
+                '/CE301_00123456_POWEP/config'
+            ),
+            payload=json.dumps(_config_payload(with_attributes=True)),
+            retain=True,
+        ),
+        call(
+            topic=(
+                'homeassistant/sensor/CE301_00123456'
+                '/CE301_00123456_POWEP/state'
+            ),
+            payload=json.dumps({'value': 'not-a-number'}),
+        ),
+    ])
+    # Cycle still completes with diagnostic sensors published
+    published_topics = [
+        c.kwargs.get('topic', c.args[0] if c.args else '')
+        for c in mock_mqtt['publish'].call_args_list
+    ]
+    assert any('CYCLE_DURATION' in topic for topic in published_topics)
+    assert any('IS_ONLINE' in topic for topic in published_topics)
+
+
+@pytest.mark.usefixtures('mock_config', 'mock_serial')
+@pytest.mark.config_yaml(_config_yaml(False))
+@pytest.mark.serial_exchange(_serial_exchange('-0.5266'))
+def test_abs_value_disabled(mock_mqtt: MockMqttT) -> None:
+    '''
+    Tests that negative readings are published unchanged when abs_value is
+    disabled.
+    '''
+    main()
+    mock_mqtt['publish'].assert_has_calls([
+        call(
+            topic=(
+                'homeassistant/sensor/CE301_00123456'
+                '/CE301_00123456_POWEP/config'
+            ),
+            payload=json.dumps(_config_payload(with_attributes=False)),
+            retain=True,
+        ),
+        call(
+            topic=(
+                'homeassistant/sensor/CE301_00123456'
+                '/CE301_00123456_POWEP/state'
+            ),
+            payload=json.dumps({'value': '-0.5266'}),
+        ),
+    ])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -92,6 +92,32 @@ def test_valid_config_file() -> None:
     assert isinstance(config.of, ConfigSchema)
     assert config.of == ConfigSchema.model_validate(valid_config)
     assert config.logging_level == logging.ERROR
+    assert config.of.parameters[0].abs_value is False
+
+
+VALID_CONFIG_ABS_VALUE_YAML = '''
+    meter:
+      port: dummy_serial
+      password: dummy_password
+    mqtt:
+      host: a_mqtt_host
+      user: a_mqtt_user
+      password: mqtt_dummy_password
+    parameters:
+        - name: dummy_param
+          address: dummy_addr
+          abs_value: true
+'''
+
+
+@pytest.mark.usefixtures('mock_config')
+@pytest.mark.config_yaml(VALID_CONFIG_ABS_VALUE_YAML)
+def test_config_abs_value_enabled() -> None:
+    '''
+    Tests for abs_value parameter property being loaded from configuration.
+    '''
+    config = EnergomeraConfig(config_file='dummy')
+    assert config.of.parameters[0].abs_value is True
 
 
 VALID_CONFIG_DEFAULT_PARAMETERS_YAML = '''
@@ -127,6 +153,25 @@ def test_valid_config_file_with_default_parameters() -> None:
     assert len(config.of.parameters) == 12
     # Verify the last parameter is the custom one
     assert config.of.parameters[-1].name == 'dummy_param'
+    # Instantaneous measurement defaults enable abs_value; historic/total and
+    # custom parameters keep it disabled
+    abs_value_by_address = {
+        param.address: param.abs_value for param in config.of.parameters[:-1]
+    }
+    assert abs_value_by_address == {
+        'ET0PE': False,
+        'ECMPE': False,
+        'ENMPE': False,
+        'EAMPE': False,
+        'ECDPE': False,
+        'POWPP': True,
+        'POWEP': True,
+        'VOLTA': True,
+        'VNULL': True,
+        'CURRE': True,
+        'FREQU': True,
+    }
+    assert config.of.parameters[-1].abs_value is False
 
 
 @pytest.mark.usefixtures('mock_config')


### PR DESCRIPTION
Allow converting numeric IEC values to absolute form before publishing to Home Assistant, exposing the original as a raw_value attribute. Enable it by default for instantaneous measurement sensors.